### PR TITLE
ENG-165: move stake from Divider to TWrapper

### DIFF
--- a/src/Divider.sol
+++ b/src/Divider.sol
@@ -82,9 +82,9 @@ contract Divider is Trust {
         require(!_exists(feed, maturity), Errors.DuplicateSeries);
         require(_isValid(feed, maturity), Errors.InvalidMaturity);
 
-        // Transfer stake asset stake from caller to this contract
+        // Transfer stake asset from caller to twrapper
         ERC20 stake = ERC20(Feed(feed).stake());
-        ERC20(stake).safeTransferFrom(msg.sender, address(this), Feed(feed).stakeSize() / _convertBase(stake.decimals()));
+        ERC20(stake).safeTransferFrom(msg.sender, Feed(feed).twrapper(), Feed(feed).stakeSize() / _convertBase(stake.decimals()));
 
         // Deploy Zeros and Claims for this new Series
         (zero, claim) = AssetDeployer(deployer).deploy(feed, maturity);
@@ -130,7 +130,7 @@ contract Divider is Trust {
         target.safeTransfer(msg.sender, series[feed][maturity].reward);
 
         ERC20 stake = ERC20(Feed(feed).stake());
-        ERC20(stake).safeTransfer(msg.sender, Feed(feed).stakeSize() / _convertBase(ERC20(stake).decimals()));
+        ERC20(stake).safeTransferFrom(Feed(feed).twrapper(), msg.sender, Feed(feed).stakeSize() / _convertBase(ERC20(stake).decimals()));
 
         emit SeriesSettled(feed, maturity, msg.sender);
     }
@@ -472,7 +472,7 @@ contract Divider is Trust {
         ERC20 target = ERC20(Feed(feed).target());
         target.safeTransfer(cup, series[feed][maturity].reward);
         ERC20 stake = ERC20(Feed(feed).stake());
-        ERC20(stake).safeTransfer(rewardee, Feed(feed).stakeSize() / _convertBase(ERC20(stake).decimals()));
+        ERC20(stake).safeTransferFrom(Feed(feed).twrapper(), rewardee, Feed(feed).stakeSize() / _convertBase(ERC20(stake).decimals()));
 
         emit Backfilled(feed, maturity, mscale, _usrs, _lscales);
     }

--- a/src/feeds/BaseFactory.sol
+++ b/src/feeds/BaseFactory.sol
@@ -64,7 +64,7 @@ abstract contract BaseFactory is Trust {
 
         // wrapped target deployment
         wtClone = twImpl.clone();
-        TWrapper(wtClone).initialize(_target, divider, reward); // deploy Target Wrapper
+        TWrapper(wtClone).initialize(divider, _target, stake, reward); // deploy Target Wrapper
 
         // feed deployment
         feedClone = feedImpl.clone();

--- a/src/tests/BaseTWrapper.t.sol
+++ b/src/tests/BaseTWrapper.t.sol
@@ -12,10 +12,11 @@ import { Errors } from "../libs/Errors.sol";
 contract Wrappers is TestHelper {
     function testDeployWrapper() public {
         BaseTWrapper twrapper = new BaseTWrapper();
-        twrapper.initialize(address(target), address(divider), address(reward));
+        twrapper.initialize(address(divider), address(target), address(stake), address(reward));
 
-        assertEq(twrapper.target(), address(target));
         assertEq(twrapper.divider(), address(divider));
+        assertEq(twrapper.target(), address(target));
+        assertEq(twrapper.stake(), address(stake));
         assertEq(twrapper.reward(), address(reward));
     }
 

--- a/src/tests/CTWrapper.tm.sol
+++ b/src/tests/CTWrapper.tm.sol
@@ -19,7 +19,9 @@ import { User } from "./test-helpers/User.sol";
 contract CTWrapperTestHelper is DSTest {
     CTWrapper internal ctwrapper;
 
+    address public constant DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
     address public constant COMP = 0xc00e94Cb662C3520282E6f5717214004A7f26888;
+    address public constant cDAI = 0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643;
 
     function setUp() public {
         CFeed feed = new CFeed(); // compound feed implementation
@@ -33,7 +35,7 @@ contract CTWrappers is CTWrapperTestHelper {
     // TODO: this is only checking the flow, we should write proper tests against mainnet using an address
     // that we know that will receive some COMP when calling the claim function
     function testClaimReward() public {
-        ctwrapper.initialize(COMP, address(this), COMP);
+        ctwrapper.initialize(address(this), cDAI, DAI, COMP);
         ctwrapper.join(address(this), 100e18);
         ctwrapper.exit(address(this), 100e18);
     }

--- a/src/tests/Twrapper.t.sol
+++ b/src/tests/Twrapper.t.sol
@@ -30,7 +30,7 @@ contract tWrappers is TestHelper {
         MockToken reward = new MockToken("Reward Airdrop Token", "RAT", 18);
         MockToken target = new MockToken("Compound Dai", "cDAI", 18);
         BaseTWrapper tWrapper = new BaseTWrapper();
-        tWrapper.initialize(address(target), address(divider), address(reward));
+        tWrapper.initialize(address(divider), address(target), address(stake), address(reward));
 
         assertEq(tWrapper.target(), address(target));
         assertEq(tWrapper.divider(), address(divider));

--- a/src/wrappers/BaseTWrapper.sol
+++ b/src/wrappers/BaseTWrapper.sol
@@ -17,8 +17,9 @@ contract BaseTWrapper is Initializable {
     using FixedMath for uint256;
 
     /// @notice Program state
-    address public target;
     address public divider;
+    address public target;
+    address public stake;
     address public reward;
     uint256 public share; // accumulated reward token per collected target
     uint256 public rewardBal; // last recorded balance of reward token
@@ -27,14 +28,17 @@ contract BaseTWrapper is Initializable {
     mapping(address => uint256) public rewarded; // reward token per collected target per user
 
     function initialize(
-        address _target,
         address _divider,
+        address _target,
+        address _stake,
         address _reward
     ) external virtual initializer {
-        target = _target;
         divider = _divider;
+        target = _target;
+        stake = _stake;
         reward = _reward;
         ERC20(target).approve(_divider, type(uint256).max);
+        ERC20(stake).approve(_divider, type(uint256).max);
 
         emit Initialized();
     }


### PR DESCRIPTION
Moving stake from Divider to TWrapper.

Note: I have not changed to name to "adapter" as suggested on the ticket just because we might be combining TWrapper with Feed and maybe on the process of doing it, it mighe be confusing if we have a new name as there will be some conflicts when merging.