### PR TITLE
ENG-298: modify adapter behaviour to support cETH correctly

### DIFF
--- a/pkg/core/src/tests/CFactory.tm.sol
+++ b/pkg/core/src/tests/CFactory.tm.sol
@@ -91,7 +91,7 @@ contract CFactories is CAdapterTestHelper {
 
     function testDeployAdapter() public {
         address f = factory.deployAdapter(cDAI);
-        CAdapter adapter = CAdapter(f);
+        CAdapter adapter = CAdapter(payable(f));
         (, , uint256 delta, , , , , , ) = CAdapter(adapter).adapterParams();
         assertTrue(address(adapter) != address(0));
         assertEq(CAdapter(adapter).getTarget(), address(cDAI));

--- a/pkg/core/src/tests/Periphery.tm.sol
+++ b/pkg/core/src/tests/Periphery.tm.sol
@@ -93,7 +93,7 @@ contract PeripheryTestHelper is DSTest {
         // periphery.setFactory(address(factory), true); // TODO: uncomment when Space ready
         // onboard adapter, target wrapper
         // address f = periphery.onboardAdapter(address(factory), cDAI); // onboard target through Periphery // TODO: uncomment when Space ready
-        adapter = CAdapter(f);
+        adapter = CAdapter(payable(f));
     }
 }
 

--- a/pkg/core/src/tests/test-helpers/Assets.sol
+++ b/pkg/core/src/tests/test-helpers/Assets.sol
@@ -9,6 +9,7 @@ library Assets {
 
     // ctokens
     address public constant cDAI = 0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643;
+    address public constant cETH = 0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5;
 
     // eth
     address public constant WSTETH = 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0;

--- a/pkg/core/src/tests/test-helpers/Hevm.sol
+++ b/pkg/core/src/tests/test-helpers/Hevm.sol
@@ -16,4 +16,6 @@ abstract contract Hevm {
     ) public virtual;
 
     function ffi(string[] calldata) external virtual returns (bytes memory);
+
+    function load(address, bytes32) external virtual returns (bytes32);
 }

--- a/pkg/core/src/tests/test-helpers/LiquidityHelper.sol
+++ b/pkg/core/src/tests/test-helpers/LiquidityHelper.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.6;
 
+import { Hevm } from "./Hevm.sol";
+
 // Internal references
 import { SafeERC20, ERC20 } from "@rari-capital/solmate/src/erc20/SafeERC20.sol";
 import { Assets } from "./Assets.sol";
@@ -22,15 +24,46 @@ interface CTokenInterface {
     function mint(uint256 mintAmount) external returns (uint256);
 }
 
+interface CETHTokenInterface {
+    ///@notice Send Ether to CEther to mint
+    function mint() external payable;
+}
+
 contract LiquidityHelper {
     using SafeERC20 for ERC20;
 
     uint24 public constant UNI_POOL_FEE = 3000; // denominated in hundredths of a bip
 
+    function giveTokens(
+        address token,
+        uint256 amount,
+        Hevm hevm
+    ) internal returns (bool) {
+        // Edge case - balance is already set for some reason
+        if (ERC20(token).balanceOf(address(this)) == amount) return true;
+
+        for (int256 i = 0; i < 100; i++) {
+            // Scan the storage for the balance storage slot
+            bytes32 prevValue = hevm.load(address(token), keccak256(abi.encode(address(this), uint256(i))));
+            hevm.store(address(token), keccak256(abi.encode(address(this), uint256(i))), bytes32(amount));
+            if (ERC20(token).balanceOf(address(this)) == amount) {
+                // Found it
+                return true;
+            } else {
+                // Keep going after restoring the original value
+                hevm.store(address(token), keccak256(abi.encode(address(this), uint256(i))), prevValue);
+            }
+        }
+
+        // We have failed if we reach here
+        return false;
+    }
+
     function addLiquidity(address[] memory assets) public {
-        address DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
+        uint256 amountIn = 10 ether;
         for (uint256 i = 0; i < assets.length; i++) {
-            swap(DAI, assets[i], 1000e18, address(this));
+            Assets.WETH.call{ value: amountIn }("");
+            swap(Assets.WETH, assets[i], amountIn, address(this));
         }
     }
 
@@ -42,7 +75,7 @@ contract LiquidityHelper {
     ) public returns (uint256) {
         uint256 amountOut = 0;
         if (tokenOut == Assets.WSTETH) {
-            uint256 stETH = StETHInterface(Assets.STETH).submit{ value: 10 ether }(address(0));
+            uint256 stETH = StETHInterface(Assets.STETH).submit{ value: amountIn }(address(0));
             ERC20(Assets.STETH).safeApprove(Assets.WSTETH, stETH);
             amountOut = WstETHInterface(Assets.WSTETH).wrap(stETH);
             emit Swapped(tokenIn, tokenOut, amountIn, amountOut);
@@ -53,6 +86,14 @@ contract LiquidityHelper {
             amountOut = CTokenInterface(Assets.cDAI).mint(amountIn);
             emit Swapped(tokenIn, tokenOut, amountIn, amountOut);
             return amountOut;
+        }
+        if (tokenOut == Assets.cETH) {
+            Assets.cETH.call{ value: amountIn }("");
+            emit Swapped(tokenIn, tokenOut, amountIn, amountOut);
+            return amountIn;
+        }
+        if (tokenOut == Assets.WETH) {
+            return amountIn;
         }
 
         // approve router to spend tokenIn


### PR DESCRIPTION
@jparklev I realised [ENG-298](https://linear.app/sense-finance/issue/ENG-298/return-weth-address-in-cethunderlying) it was not only about returning WETH in when calling `underlying()` for the cETH adapter but also:
- getUnderlyingPrice() --> should return 1e18
- wrapUnderlying --> would receive underlying (WETH), convert it to ETH and then mint() cETH on Compound
- unwrapTarget --> receives cETH, redeems it for ETH on Compound and then wrap it to WETH (on WETH contract)

What I've done it similar to how the wstETH adapter works.

Let me know your thoughts!