### PR TITLE
feat(deploy): give underlying tokens nicer names

### DIFF
--- a/pkg/deployments/deploy/simulated/01-adapters.js
+++ b/pkg/deployments/deploy/simulated/01-adapters.js
@@ -67,10 +67,12 @@ module.exports = async function ({ ethers, deployments, getNamedAccounts }) {
   console.log("Deploying Targets & Adapters");
   for (let targetName of global.TARGETS) {
     console.log(`Deploying simulated ${targetName}`);
+    const underlyingRegexRes = targetName.match(/[^A-Z]*(.*)/)
+    const underlyingName = (underlyingRegexRes && underlyingRegexRes[1]) || `UNDERLYING-${targetName}`
     const { address: mockUnderlyingAddress } = await deploy(targetName, {
       contract: "MockToken",
       from: deployer,
-      args: [`UNDERLYING-${targetName}`, `UNDERLYING-${targetName}`, 18],
+      args: [underlyingName, underlyingName, 18],
       log: true,
     });
 


### PR DESCRIPTION
assumes first capital letter is the where the underlying name starts - true for our tokens, but not sure if it'll be true for all tokens.

But for now, at least on our portal the underlying display names will look nice!