### PR TITLE
feat(Divider): add target balance to Divider.Issued

### DIFF
--- a/pkg/core/src/Divider.sol
+++ b/pkg/core/src/Divider.sol
@@ -198,7 +198,7 @@ contract Divider is Trust, ReentrancyGuard, Pausable {
         Zero(series[adapter][maturity].zero).mint(msg.sender, uBal);
         Claim(series[adapter][maturity].claim).mint(msg.sender, uBal);
 
-        emit Issued(adapter, maturity, uBal, msg.sender);
+        emit Issued(adapter, maturity, tBal, uBal, msg.sender);
     }
 
     /// @notice Reconstitute Target by burning Zeros and Claims
@@ -627,7 +627,7 @@ contract Divider is Trust, ReentrancyGuard, Pausable {
         address indexed target
     );
     /// -***- middle
-    event Issued(address indexed adapter, uint256 indexed maturity, uint256 balance, address indexed sender);
+    event Issued(address indexed adapter, uint256 indexed maturity, uint256 balanceIn, uint256 balanceOut, address indexed sender);
     event Combined(address indexed adapter, uint256 indexed maturity, uint256 balance, address indexed sender);
     event Collected(address indexed adapter, uint256 indexed maturity, uint256 collected);
     /// ----* end


### PR DESCRIPTION
Used to calculate the purchase price of claims.

For context, we need the amount of targets used to issue zeros and claims to calculate the claims purchase price. The amount of target refunded by selling the zeros is subtracted from that value (which we can currently calculate using the new swap event).

We'll also need to associate each Issued event with the original sender (the user), which is not implemented here. 
Alternatively, it's odd but we can also emit the scale value as part of the Event, so we can back out the original amount of target swapped in, as long as the Issued event is from the same block as the corresponding Swap event. (that is, for all the `swapTargetForClaims` events, we find the corresponding block numbers, and then find the `Issued` events on the same block. We get the scale value from one of those events, and then use that to calculate the number of target passed into `Divider.issue`.)

Misc:
- add `balanceIn`/`balanceOut` to `Combined` for symmetry
- `balanceIn`/`balanceOut` -> `amountIn` and `amountOut`?