### PR TITLE
chore(core): combine stake data and target address into single adapter getter

### DIFF
--- a/pkg/core/src/Divider.sol
+++ b/pkg/core/src/Divider.sol
@@ -90,8 +90,7 @@ contract Divider is Trust, ReentrancyGuard, Pausable {
         require(_isValid(adapter, maturity), Errors.InvalidMaturity);
 
         // Transfer stake asset stake from caller to adapter
-        address target = Adapter(adapter).getTarget();
-        (address stake, uint256 stakeSize) = Adapter(adapter).getStakeData();
+        (address target, address stake, uint256 stakeSize) = Adapter(adapter).getStakeAndTarget();
 
         // Deploy Zeros and Claims for this new Series
         (zero, claim) = TokenHandler(tokenHandler).deploy(adapter, maturity);
@@ -134,8 +133,7 @@ contract Divider is Trust, ReentrancyGuard, Pausable {
         }
 
         // Reward the caller for doing the work of settling the Series at around the correct time
-        address target = Adapter(adapter).getTarget();
-        (address stake, uint256 stakeSize) = Adapter(adapter).getStakeData();
+        (address target, address stake, uint256 stakeSize) = Adapter(adapter).getStakeAndTarget();
         ERC20(target).safeTransferFrom(adapter, msg.sender, series[adapter][maturity].reward);
         ERC20(stake).safeTransferFrom(adapter, msg.sender, _convertToBase(stakeSize, ERC20(stake).decimals()));
 
@@ -512,8 +510,7 @@ contract Divider is Trust, ReentrancyGuard, Pausable {
             lscales[adapter][maturity][_usrs[i]] = _lscales[i];
         }
 
-        address target = Adapter(adapter).getTarget();
-        (address stake, uint256 stakeSize) = Adapter(adapter).getStakeData();
+        (address target, address stake, uint256 stakeSize) = Adapter(adapter).getStakeAndTarget();
 
         // Determine where the stake should go depending on where we are relative to the maturity date
         address stakeDst = block.timestamp <= maturity + SPONSOR_WINDOW ? series[adapter][maturity].sponsor : cup;

--- a/pkg/core/src/Periphery.sol
+++ b/pkg/core/src/Periphery.sol
@@ -60,7 +60,7 @@ contract Periphery is Trust {
     /// @param adapter Adapter to associate with the Series
     /// @param maturity Maturity date for the Series, in units of unix time
     function sponsorSeries(address adapter, uint48 maturity) external returns (address zero, address claim) {
-        (address stake, uint256 stakeSize) = Adapter(adapter).getStakeData();
+        (, address stake, uint256 stakeSize) = Adapter(adapter).getStakeAndTarget();
 
         // transfer stakeSize from sponsor into this contract
         uint256 stakeDecimals = ERC20(stake).decimals();

--- a/pkg/core/src/adapters/BaseAdapter.sol
+++ b/pkg/core/src/adapters/BaseAdapter.sol
@@ -179,8 +179,8 @@ abstract contract BaseAdapter is Initializable {
         return (adapterParams.minm, adapterParams.maxm);
     }
 
-    function getStakeData() external view returns (address, uint256) {
-        return (adapterParams.stake, adapterParams.stakeSize);
+    function getStakeAndTarget() external view returns (address, address, uint256) {
+        return (adapterParams.target, adapterParams.stake, adapterParams.stakeSize);
     }
 
     function getMode() external view returns (uint8) {


### PR DESCRIPTION
Because we need `target` almost everywhere we need `stake` & `stakeSize`, we can save ourselves the external call. The one place we don't need `target` immediately (`Periphery.sposorSeries`), we load it later in the TX anyway, so we'll get the benefit of a warmed `SLOAD` anyway.