### PR TITLE
ENG-376: fix(Divider): scale loop on backfillScale

### DIFF
--- a/pkg/core/src/tests/Divider.t.sol
+++ b/pkg/core/src/tests/Divider.t.sol
@@ -846,8 +846,7 @@ contract Dividers is TestHelper {
         (, , , , , , uint256 mscale, , ) = divider.series(address(adapter), maturity);
         (, uint256 lvalue) = adapter.lscale();
         uint256 cscale = block.timestamp >= maturity ? mscale : lvalue;
-        uint256 collect = cBalanceBefore.fdiv(lscale, FixedMath.WAD) -
-            cBalanceBefore.fdiv(cscale, FixedMath.WAD);
+        uint256 collect = cBalanceBefore.fdiv(lscale, FixedMath.WAD) - cBalanceBefore.fdiv(cscale, FixedMath.WAD);
         assertEq(cBalanceBefore, cBalanceAfter);
         assertEq(collected, collect);
         assertEq(tBalanceAfter, tBalanceBefore + collected);
@@ -1408,6 +1407,45 @@ contract Dividers is TestHelper {
         uint256 cupStakeBalanceAfter = stake.balanceOf(address(this));
         assertEq(cupTargetBalanceAfter, cupTargetBalanceBefore + fee);
         assertEq(cupStakeBalanceAfter, cupStakeBalanceBefore + convertToBase(STAKE_SIZE, stake.decimals()));
+    }
+
+    function testFuzzBackfillOnlyLScale(uint128 tBal) public {
+        uint48 maturity = getValidMaturity(2021, 10);
+        uint256 sponsorTargetBalanceBefore = target.balanceOf(address(alice));
+        uint256 sponsorStakeBalanceBefore = stake.balanceOf(address(alice));
+        uint256 cupTargetBalanceBefore = target.balanceOf(address(this));
+        uint256 cupStakeBalanceBefore = stake.balanceOf(address(this));
+        sponsorSampleSeries(address(alice), maturity);
+        hevm.warp(block.timestamp + 1 days);
+
+        uint256 tDecimals = target.decimals();
+        uint256 tBase = 10**tDecimals;
+        uint256 fee = convertToBase(ISSUANCE_FEE, tDecimals).fmul(tBal, tBase); // 1 target
+        bob.doIssue(address(adapter), maturity, tBal);
+
+        hevm.warp(maturity + SPONSOR_WINDOW + 1 seconds);
+        divider.setAdapter(address(adapter), false);
+
+        usrs.push(address(alice));
+        usrs.push(address(bob));
+        lscales.push(5e17);
+        lscales.push(4e17);
+        divider.backfillScale(address(adapter), maturity, 0, usrs, lscales);
+
+        (, , , , , uint256 mscale, , , ) = divider.series(address(adapter), maturity);
+        assertEq(mscale, 0);
+        assertEq(target.balanceOf(address(alice)), sponsorTargetBalanceBefore);
+        assertEq(
+            stake.balanceOf(address(alice)),
+            sponsorStakeBalanceBefore - convertToBase(STAKE_SIZE, stake.decimals())
+        );
+        assertEq(target.balanceOf(address(this)), cupTargetBalanceBefore);
+        assertEq(stake.balanceOf(address(this)), cupStakeBalanceBefore);
+
+        uint256 lscale = divider.lscales(address(adapter), maturity, address(alice));
+        assertEq(lscale, lscales[0]);
+        lscale = divider.lscales(address(adapter), maturity, address(bob));
+        assertEq(lscale, lscales[1]);
     }
 
     /* ========== setAdapter() tests ========== */


### PR DESCRIPTION
ABDK context: "This loop doesn't scale and for a really big number of user may not fit into the block gas limit. "

Basically, the loop they refer to is the one of the backfill. So, I've implemented this solution in which we are just adding a check whether the `mscale` we are passing is greater than 0. If that's the case, we run the backfil normally (backfill `lscales` + set `mscale` + transfer reward and stake). If `mscale` is 0, we only backfill `lscales`.

So, in the case we have a large number of users, we could call this fn passing a 0 `mscale` and, finally, on the last call, we pass an`mscale` > 0 which will set that mscale (making the Series to be settled) and transfer the rewards and stake.

WDYT? @jparklev 