### PR TITLE
ENG-375: refactor: round up (towards the protocol)

### DIFF
--- a/pkg/core/src/Divider.sol
+++ b/pkg/core/src/Divider.sol
@@ -335,8 +335,8 @@ contract Divider is Trust, ReentrancyGuard, Pausable {
         // Because maxscale must be increasing, the Target balance needed to equal `u` decreases, and that "excess"
         // is what Claim holders are collecting
         uint256 tBalNow = uBal.fdivUp(_series.maxscale); // preventive round-up towards the protocol
-        uint256 ltBal = uBal.fdiv(lscale);
-        collected = ltBal > tBalNow ? ltBal - tBalNow : 0;
+        uint256 tBalPrev = uBal.fdiv(lscale);
+        collected = tBalPrev > tBalNow ? tBalPrev - tBalNow : 0;
         ERC20(Adapter(adapter).getTarget()).safeTransferFrom(adapter, usr, collected);
         Adapter(adapter).notify(usr, collected, false); // Distribute reward tokens
 

--- a/pkg/core/src/modules/GClaimManager.sol
+++ b/pkg/core/src/modules/GClaimManager.sol
@@ -122,7 +122,10 @@ contract GClaimManager {
         }
 
         if (scale - initScale > 0) {
-            tBal = ((uBal * scale) / (scale - initScale)).fdivUp(10**18, 1);
+            tBal = ((uBal.fmul(scale, FixedMath.WAD)).fdiv(scale - initScale, FixedMath.WAD)).fdivUp(
+                10**18,
+                FixedMath.WAD
+            );
         }
     }
 

--- a/pkg/core/src/tests/Claim.t.sol
+++ b/pkg/core/src/tests/Claim.t.sol
@@ -10,6 +10,7 @@ contract Claims is TestHelper {
     using FixedMath for uint256;
 
     function testFuzzCollect(uint128 tBal) public {
+        tBal = fuzzWithBounds(tBal, 1e12);
         uint48 maturity = getValidMaturity(2021, 10);
         (, address claim) = sponsorSampleSeries(address(alice), maturity);
         hevm.warp(block.timestamp + 1 days);
@@ -34,6 +35,7 @@ contract Claims is TestHelper {
     }
 
     function testFuzzCollectOnTransfer(uint128 tBal) public {
+        tBal = fuzzWithBounds(tBal, 1e12);
         uint48 maturity = getValidMaturity(2021, 10);
         (, address claim) = sponsorSampleSeries(address(alice), maturity);
         hevm.warp(block.timestamp + 1 days);
@@ -63,6 +65,7 @@ contract Claims is TestHelper {
     }
 
     function testFuzzCollectOnTransferFrom(uint128 tBal) public {
+        tBal = fuzzWithBounds(tBal, 1e12);
         uint48 maturity = getValidMaturity(2021, 10);
         (, address claim) = sponsorSampleSeries(address(alice), maturity);
         hevm.warp(block.timestamp + 1 days);


### PR DESCRIPTION
I'm using `fdivUp` (already in FixedMath.WAD) to round up and prevent the potential situation in which the protocol could not pay in full.