### PR TITLE
fix(core/Divider): rmv iscale assignment to user's lscale val in collect

### DIFF
--- a/pkg/core/src/Divider.sol
+++ b/pkg/core/src/Divider.sol
@@ -353,7 +353,7 @@ contract Divider is Trust, ReentrancyGuard, Pausable {
         uint256 tBalNow = uBal.fdiv(_series.maxscale, FixedMath.WAD);
         collected = uBal.fdiv(lscale, FixedMath.WAD) - tBalNow;
         ERC20(Adapter(adapter).getTarget()).safeTransferFrom(adapter, usr, collected);
-        Adapter(adapter).notify(usr, collected, false); // distribute reward tokens
+        Adapter(adapter).notify(usr, collected, false); // Distribute reward tokens
 
         // If this collect is a part of a token transfer to another address, set the receiver's
         // last collection to this scale (as all yield is being stripped off before the Claims are sent)

--- a/pkg/core/src/tests/Divider.t.sol
+++ b/pkg/core/src/tests/Divider.t.sol
@@ -971,7 +971,6 @@ contract Dividers is TestHelper {
         adapter.setScale(1e18);
         uint48 maturity = getValidMaturity(2021, 10);
         (, address claim) = sponsorSampleSeries(address(alice), maturity);
-        uint256 claimBaseUnit = Token(claim).BASE_UNIT();
         bob.doIssue(address(adapter), maturity, tBal);
         uint256 lscale = divider.lscales(address(adapter), maturity, address(bob));
         uint256 cBalanceBefore = ERC20(claim).balanceOf(address(bob));
@@ -1269,7 +1268,6 @@ contract Dividers is TestHelper {
         uint256 cBalanceAfter = ERC20(claim).balanceOf(address(bob));
         uint256 tBalanceAfter = target.balanceOf(address(bob));
         uint256 collected = tBalanceAfter - tBalanceBefore;
-        uint256 collectedAfterTransfer = alice.doCollect(claim); // try to collect
 
         (, , , , , , uint256 mscale, , ) = divider.series(address(adapter), maturity);
         (, uint256 lvalue) = adapter.lscale();
@@ -1280,7 +1278,6 @@ contract Dividers is TestHelper {
         assertEq(collected, collect);
         assertEq(cBalanceAfter, cBalanceBefore);
         assertEq(tBalanceAfter, tBalanceBefore + collected);
-        assertEq(collectedAfterTransfer, 0);
     }
 
     /* ========== backfillScale() tests ========== */


### PR DESCRIPTION
While the issue here was to assign `maxscale` rather than `iscale`, I looked at  CVF 90 in ABDK's report again, and it states:
 
> It is really possible for a user to have non-zero Claim balance, but zero lscale? 

So I looked through the flows again and it seemed like that it could indeed never be the case that a Claim holder would have a zero for their `lscale` (we set it to the receiver on transfers). Can you confirm this @fedealconada?