### PR TITLE
Gen 611 more comments

### DIFF
--- a/pkg/core/src/Divider.sol
+++ b/pkg/core/src/Divider.sol
@@ -294,7 +294,7 @@ contract Divider is Trust, ReentrancyGuard, Pausable {
         tBal = uBal.fdiv(cscale);
         ERC20(Adapter(adapter).target()).safeTransferFrom(adapter, msg.sender, tBal);
 
-        // Notify the Adapter only when Series is not settled, because when it is, the _collect() call above 
+        // Notify the Adapter only when Series is not settled, because when it is, the _collect() call above
         // would trigger a _redeemYT and call notify
         if (!settled) Adapter(adapter).notify(msg.sender, tBal, false);
         unchecked {
@@ -583,7 +583,7 @@ contract Divider is Trust, ReentrancyGuard, Pausable {
 
             ERC20(target).safeTransferFrom(adapter, cup, _series.reward);
             series[adapter][maturity].reward = 0;
-            
+
             ERC20(stake).safeTransferFrom(adapter, stakeDst, stakeSize);
         }
 

--- a/pkg/core/src/Periphery.sol
+++ b/pkg/core/src/Periphery.sol
@@ -167,8 +167,8 @@ contract Periphery is Trust {
     ) external returns (uint256 ptBal) {
         ERC20 underlying = ERC20(Adapter(adapter).underlying());
         underlying.safeTransferFrom(msg.sender, address(this), uBal); // pull underlying
-        underlying.approve(adapter, uBal);                            // approve adapter to pull uBal
-        uint256 tBal = Adapter(adapter).wrapUnderlying(uBal);         // wrap underlying into target
+        underlying.approve(adapter, uBal); // approve adapter to pull uBal
+        uint256 tBal = Adapter(adapter).wrapUnderlying(uBal); // wrap underlying into target
         ptBal = _swapTargetForPTs(adapter, maturity, tBal, minAccepted);
     }
 
@@ -202,8 +202,8 @@ contract Periphery is Trust {
     ) external returns (uint256 ytBal) {
         ERC20 underlying = ERC20(Adapter(adapter).underlying());
         underlying.safeTransferFrom(msg.sender, address(this), uBal); // pull underlying
-        underlying.approve(adapter, uBal);                            // approve adapter to pull underlying
-        uint256 tBal = Adapter(adapter).wrapUnderlying(uBal);         // wrap underlying into target
+        underlying.approve(adapter, uBal); // approve adapter to pull underlying
+        uint256 tBal = Adapter(adapter).wrapUnderlying(uBal); // wrap underlying into target
         ytBal = _swapTargetForYTs(adapter, maturity, tBal, minAccepted);
     }
 
@@ -234,9 +234,9 @@ contract Periphery is Trust {
         uint256 minAccepted
     ) external returns (uint256 uBal) {
         uint256 tBal = _swapPTsForTarget(adapter, maturity, ptBal, minAccepted); // swap Principal Tokens for target
-        ERC20(Adapter(adapter).target()).approve(adapter, tBal);                 // approve adapter to pull target
-        uBal = Adapter(adapter).unwrapTarget(tBal);                              // unwrap target into underlying
-        ERC20(Adapter(adapter).underlying()).safeTransfer(msg.sender, uBal);     // transfer underlying to msg.sender
+        ERC20(Adapter(adapter).target()).approve(adapter, tBal); // approve adapter to pull target
+        uBal = Adapter(adapter).unwrapTarget(tBal); // unwrap target into underlying
+        ERC20(Adapter(adapter).underlying()).safeTransfer(msg.sender, uBal); // transfer underlying to msg.sender
     }
 
     /// @notice Swap YT for Target of a particular series
@@ -494,7 +494,7 @@ contract Periphery is Trust {
         // Because there's some margin of error in the pricing functions here, smaller
         // swaps will be unreliable. Tokens with more than 18 decimals are not supported.
         if (ytBal * 10**(18 - ERC20(yt).decimals()) <= MIN_YT_SWAP_IN) revert Errors.SwapTooSmall();
-        
+
         BalancerPool pool = BalancerPool(spaceFactory.pools(adapter, maturity));
 
         // Transfer YTs into this contract if needed
@@ -622,9 +622,8 @@ contract Periphery is Trust {
         uint256 _ptBal;
         (tBal, _ptBal) = _removeLiquidityFromSpace(poolId, pt, target, minAmountsOut, lpBal);
 
-        // If the series has matured 
+        // If the series has matured
         if (divider.mscale(adapter, maturity) > 0) {
-
             // Some adapters restrict redemption
             if (uint256(Adapter(adapter).level()).redeemRestricted()) {
                 ERC20(pt).safeTransfer(msg.sender, _ptBal);


### PR DESCRIPTION
Misc improvements, comments, and a question: 

1. Added some more comments to improve readability
2. I didn't check for Natspec compatibility but expect that we'll have a moment to improve compliance before launch
3. I noticed that `issuance` is used to describe the timestamp of `series initialization`. I think this has the potential to cause confusion because _issuance_ is also used to describe the moment that a user issues freshly minted PTs and YTs. Could we consider another name?