### PR TITLE
GEN-820: swappable periphery params

### DIFF
--- a/pkg/core/src/Periphery.sol
+++ b/pkg/core/src/Periphery.sol
@@ -44,15 +44,15 @@ contract Periphery is Trust, IERC3156FlashBorrower {
     Divider public immutable divider;
 
     /// @notice Sense core Divider address
-    PoolManager public immutable poolManager;
-
-    /// @notice Sense core Divider address
-    SpaceFactoryLike public immutable spaceFactory;
-
-    /// @notice Sense core Divider address
     BalancerVault public immutable balancerVault;
 
     /* ========== PUBLIC MUTABLE STORAGE ========== */
+
+    /// @notice Sense core Divider address
+    PoolManager public poolManager;
+
+    /// @notice Sense core Divider address
+    SpaceFactoryLike public spaceFactory;
 
     /// @notice adapter factories -> is supported
     mapping(address => bool) public factories;
@@ -406,6 +406,20 @@ contract Periphery is Trust, IERC3156FlashBorrower {
         if (factories[f] == isOn) revert Errors.ExistingValue();
         factories[f] = isOn;
         emit FactoryChanged(f, isOn);
+    }
+
+    /// @notice Update the address for the Space Factory
+    /// @param newSpaceFactory The Space Factory addresss to set
+    function setSpaceFactory(address newSpaceFactory) external requiresTrust {
+        spaceFactory = SpaceFactoryLike(newSpaceFactory);
+        emit SpaceFactoryChanged(newSpaceFactory);
+    }
+
+    /// @notice Update the address for the Pool Manager
+    /// @param newPoolManager The Pool Manager addresss to set
+    function setPoolManager(address newPoolManager) external requiresTrust {
+        poolManager = PoolManager(newPoolManager);
+        emit PoolManagerChanged(newPoolManager);
     }
 
     /// @dev Verifies an Adapter and optionally adds the Target to the money market
@@ -804,6 +818,8 @@ contract Periphery is Trust, IERC3156FlashBorrower {
     /* ========== LOGS ========== */
 
     event FactoryChanged(address indexed factory, bool indexed isOn);
+    event SpaceFactoryChanged(address newSpaceFactory);
+    event PoolManagerChanged(address newPoolManager);
     event SeriesSponsored(address indexed adapter, uint256 indexed maturity, address indexed sponsor);
     event AdapterDeployed(address indexed adapter);
     event AdapterOnboarded(address indexed adapter);

--- a/pkg/core/src/tests/Periphery.t.sol
+++ b/pkg/core/src/tests/Periphery.t.sol
@@ -163,6 +163,78 @@ contract PeripheryTest is TestHelper {
         }
     }
 
+    /* ========== admin update storage addresses ========== */
+
+    event PoolManagerChanged(address);
+
+    function testUpdatePoolManager() public {
+        hevm.record();
+        address NEW_POOL_MANAGER = address(0xbabe);
+
+        // Expect the new Pool Manager to be set, and for a "change" event to be emitted
+        hevm.expectEmit(false, false, false, true);
+        emit PoolManagerChanged(NEW_POOL_MANAGER);
+
+        // 1. Update the Pool Manager address
+        periphery.setPoolManager(NEW_POOL_MANAGER);
+        ( , bytes32[] memory writes) = hevm.accesses(address(periphery));
+
+        // Check that the storage slot was updated correctly
+        assertEq(address(periphery.poolManager()), NEW_POOL_MANAGER);
+        // Check that only one storage slot was written to
+        assertEq(writes.length, 1);
+    }
+
+    event SpaceFactoryChanged(address);
+
+    function testUpdateSpaceFactory() public {
+        hevm.record();
+        address NEW_SPACE_FACTORY = address(0xbabe);
+
+        // Expect the new Space Factory to be set, and for a "change" event to be emitted
+        hevm.expectEmit(false, false, false, true);
+        emit SpaceFactoryChanged(NEW_SPACE_FACTORY);
+
+        // 1. Update the Space Factory address
+        periphery.setSpaceFactory(NEW_SPACE_FACTORY);
+        ( , bytes32[] memory writes) = hevm.accesses(address(periphery));
+
+        // Check that the storage slot was updated correctly
+        assertEq(address(periphery.spaceFactory()), NEW_SPACE_FACTORY);
+        // Check that only one storage slot was written to
+        assertEq(writes.length, 1);
+    }
+
+    function testFuzzUpdatePoolManager(address lad) public {
+        hevm.record();
+        hevm.assume(lad != address(this)); // For any address other than the testing contract
+        address NEW_POOL_MANAGER = address(0xbabe);
+
+        // 1. Impersonate the fuzzed address and try to update the Pool Manager address
+        hevm.prank(lad);
+        hevm.expectRevert("UNTRUSTED");
+        periphery.setPoolManager(NEW_POOL_MANAGER);
+
+        ( , bytes32[] memory writes) = hevm.accesses(address(periphery));
+        // Check that only no storage slots were written to
+        assertEq(writes.length, 0);
+    }
+
+    function testFuzzUpdateSpaceFactory(address lad) public {
+        hevm.record();
+        hevm.assume(lad != address(this)); // For any address other than the testing contract
+        address NEW_SPACE_FACTORY = address(0xbabe);
+
+        // 1. Impersonate the fuzzed address and try to update the Space Factory address
+        hevm.prank(lad);
+        hevm.expectRevert("UNTRUSTED");
+        periphery.setSpaceFactory(NEW_SPACE_FACTORY);
+
+        ( , bytes32[] memory writes) = hevm.accesses(address(periphery));
+        // Check that only no storage slots were written to
+        assertEq(writes.length, 0);
+    }
+
     /* ========== admin onboarding tests ========== */
 
     function testAdminOnboardVerifiedAdapter() public {

--- a/pkg/core/src/tests/Periphery.t.sol
+++ b/pkg/core/src/tests/Periphery.t.sol
@@ -177,7 +177,7 @@ contract PeripheryTest is TestHelper {
 
         // 1. Update the Pool Manager address
         periphery.setPoolManager(NEW_POOL_MANAGER);
-        ( , bytes32[] memory writes) = hevm.accesses(address(periphery));
+        (, bytes32[] memory writes) = hevm.accesses(address(periphery));
 
         // Check that the storage slot was updated correctly
         assertEq(address(periphery.poolManager()), NEW_POOL_MANAGER);
@@ -197,7 +197,7 @@ contract PeripheryTest is TestHelper {
 
         // 1. Update the Space Factory address
         periphery.setSpaceFactory(NEW_SPACE_FACTORY);
-        ( , bytes32[] memory writes) = hevm.accesses(address(periphery));
+        (, bytes32[] memory writes) = hevm.accesses(address(periphery));
 
         // Check that the storage slot was updated correctly
         assertEq(address(periphery.spaceFactory()), NEW_SPACE_FACTORY);
@@ -215,7 +215,7 @@ contract PeripheryTest is TestHelper {
         hevm.expectRevert("UNTRUSTED");
         periphery.setPoolManager(NEW_POOL_MANAGER);
 
-        ( , bytes32[] memory writes) = hevm.accesses(address(periphery));
+        (, bytes32[] memory writes) = hevm.accesses(address(periphery));
         // Check that only no storage slots were written to
         assertEq(writes.length, 0);
     }
@@ -230,7 +230,7 @@ contract PeripheryTest is TestHelper {
         hevm.expectRevert("UNTRUSTED");
         periphery.setSpaceFactory(NEW_SPACE_FACTORY);
 
-        ( , bytes32[] memory writes) = hevm.accesses(address(periphery));
+        (, bytes32[] memory writes) = hevm.accesses(address(periphery));
         // Check that only no storage slots were written to
         assertEq(writes.length, 0);
     }


### PR DESCRIPTION
## Motivation

To make future migrations easier by not requiring us to redeploy the Periphery every time we change the Space Factory or Pool Manager

## Solution

Remove the immutable modifier from the `poolManager` and `spaceFactory` storage variables, then add setters that let trusted actors update the values

## Implementer Checklist
- [x]  [FIRST TIME ONLY] Review the [solcurity](https://github.com/Rari-Capital/solcurity) standard
- [ ]  [OPTIONAL] Create a reference implementation (in python or JS)
- [x]   Create a short "Motivation" section for the PR
- [x]  Write a spec for the feature and put it in the PR description – basic function names and expected state transitions is OK
- [x]  Check all of the new revert paths with concrete tests
- [x]  Check all of the new storage slot writes with concrete tests – do not make the passing test case the trivial case!
- [x]  Go line-by-line through the new code and ensure it has all been covered by concrete tests – since we don’t have a coverage engine for foundry yet, you can imagine how one might check that each different code path is covered
- [x]  Simplify the implementation and spend some time trying to minimize gas costs
- [x]  Write fuzz tests for the feature – try everything to break the implementation (is this function monotonically in/decreasing, should it always be less than something else, etc)
- [x]  Capture bugs discovered during the above steps in concrete tests (regression tests)
- [ ]  Add integration tests – fuzz or concrete tests that test how the new code affects the entire system, either locally or with a mainnet fork
- [ ]  [OPTIONAL] Integrate the feature into the deployment scripts
- [ ]  [OPTIONAL] Add new sanity checks to the deployment scripts
- [ ]  Get the PR reviewed by at least two people


