### PR TITLE
chore(core/Periphery): add previous contract address to change event

### DIFF
--- a/pkg/core/src/Periphery.sol
+++ b/pkg/core/src/Periphery.sol
@@ -404,15 +404,15 @@ contract Periphery is Trust, IERC3156FlashBorrower {
     /// @notice Update the address for the Space Factory
     /// @param newSpaceFactory The Space Factory addresss to set
     function setSpaceFactory(address newSpaceFactory) external requiresTrust {
+        emit SpaceFactoryChanged(address(spaceFactory), newSpaceFactory);
         spaceFactory = SpaceFactoryLike(newSpaceFactory);
-        emit SpaceFactoryChanged(newSpaceFactory);
     }
 
     /// @notice Update the address for the Pool Manager
     /// @param newPoolManager The Pool Manager addresss to set
     function setPoolManager(address newPoolManager) external requiresTrust {
+        emit PoolManagerChanged(address(poolManager), newPoolManager);
         poolManager = PoolManager(newPoolManager);
-        emit PoolManagerChanged(newPoolManager);
     }
 
     /// @dev Verifies an Adapter and optionally adds the Target to the money market
@@ -788,8 +788,8 @@ contract Periphery is Trust, IERC3156FlashBorrower {
     /* ========== LOGS ========== */
 
     event FactoryChanged(address indexed factory, bool indexed isOn);
-    event SpaceFactoryChanged(address newSpaceFactory);
-    event PoolManagerChanged(address newPoolManager);
+    event SpaceFactoryChanged(address oldSpaceFactory, address newSpaceFactory);
+    event PoolManagerChanged(address oldPoolManager, address newPoolManager);
     event SeriesSponsored(address indexed adapter, uint256 indexed maturity, address indexed sponsor);
     event AdapterDeployed(address indexed adapter);
     event AdapterOnboarded(address indexed adapter);

--- a/pkg/core/src/tests/Periphery.t.sol
+++ b/pkg/core/src/tests/Periphery.t.sol
@@ -165,15 +165,17 @@ contract PeripheryTest is TestHelper {
 
     /* ========== admin update storage addresses ========== */
 
-    event PoolManagerChanged(address);
+    event PoolManagerChanged(address, address);
 
     function testUpdatePoolManager() public {
+        address oldPoolManager = address(periphery.poolManager());
+
         hevm.record();
         address NEW_POOL_MANAGER = address(0xbabe);
 
         // Expect the new Pool Manager to be set, and for a "change" event to be emitted
         hevm.expectEmit(false, false, false, true);
-        emit PoolManagerChanged(NEW_POOL_MANAGER);
+        emit PoolManagerChanged(oldPoolManager, NEW_POOL_MANAGER);
 
         // 1. Update the Pool Manager address
         periphery.setPoolManager(NEW_POOL_MANAGER);
@@ -185,15 +187,17 @@ contract PeripheryTest is TestHelper {
         assertEq(writes.length, 1);
     }
 
-    event SpaceFactoryChanged(address);
+    event SpaceFactoryChanged(address, address);
 
     function testUpdateSpaceFactory() public {
+        address oldSpaceFactory = address(periphery.spaceFactory());
+
         hevm.record();
         address NEW_SPACE_FACTORY = address(0xbabe);
 
         // Expect the new Space Factory to be set, and for a "change" event to be emitted
         hevm.expectEmit(false, false, false, true);
-        emit SpaceFactoryChanged(NEW_SPACE_FACTORY);
+        emit SpaceFactoryChanged(oldSpaceFactory, NEW_SPACE_FACTORY);
 
         // 1. Update the Space Factory address
         periphery.setSpaceFactory(NEW_SPACE_FACTORY);


### PR DESCRIPTION
## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Had a thought for an improvement to https://github.com/sense-finance/sense-v1/pull/238 based off of this message on the tribe discord 

<img width="930" alt="Screen Shot 2022-04-26 at 4 08 17 PM" src="https://user-images.githubusercontent.com/24902242/165383479-084f5716-5127-4d0a-abbf-73c592cd7dda.png">


## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Add the `Changed` event in before the storage update so that we can emit the previous address as well

## Implementer Checklist

<!--
Fill out the checklist below as applicable to your change. Bug fixes and new features must 
check off all of the required items.
-->
N/A