### PR TITLE
chore(core/Periphery): add yt buying event

### DIFF
--- a/pkg/core/src/Periphery.sol
+++ b/pkg/core/src/Periphery.sol
@@ -716,6 +716,7 @@ contract Periphery is Trust, IERC3156FlashBorrower {
 
         targetBal = ERC20(Adapter(adapter).target()).balanceOf(address(this));
         ytBal = ERC20(divider.yt(adapter, maturity)).balanceOf(address(this));
+        emit YTsPurchased(msg.sender, adapter, maturity, targetIn, targetBal, ytBal);
     }
 
     /// @dev ERC-3156 Flash loan callback
@@ -828,6 +829,14 @@ contract Periphery is Trust, IERC3156FlashBorrower {
     event AdapterDeployed(address indexed adapter);
     event AdapterOnboarded(address indexed adapter);
     event AdapterVerified(address indexed adapter);
+    event YTsPurchased(
+        address indexed sender,
+        address adapter,
+        uint256 maturity,
+        uint256 targetIn,
+        uint256 targetReturned,
+        uint256 ytOut
+    );
     event Swapped(
         address indexed sender,
         bytes32 indexed poolId,


### PR DESCRIPTION
## Motivation

The existing `Swapped` event doesn't give us enough information to establish a cost basis for users' YTs. See the comment here: https://github.com/sense-finance/sense-subgraph/pull/17/files#r861448409

## Solution

Add a `YTPurchased` event that provides both the initial target in and the target returned

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Implementer Checklist

N/A