### PR TITLE
refactor(core/adapters): make maturity bounds function virtual

### DIFF
--- a/pkg/core/src/adapters/BaseAdapter.sol
+++ b/pkg/core/src/adapters/BaseAdapter.sol
@@ -167,7 +167,7 @@ abstract contract BaseAdapter is IERC3156FlashLender {
 
     /* ========== PUBLIC STORAGE ACCESSORS ========== */
 
-    function getMaturityBounds() external view returns (uint256, uint256) {
+    function getMaturityBounds() external view virtual returns (uint256, uint256) {
         return (adapterParams.minm, adapterParams.maxm);
     }
 


### PR DESCRIPTION
## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Enable the [auto roller](https://github.com/sense-finance/auto-roller) to prevent new Series from being initialized


## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Make the maturity bounds function virtual so that custom adapters can be written that have custom logic for setting the maturity bounds. This allows them to _disable_ new series by setting the `maxm` to 0, then conditionally changing it when it's ready to allow new Series again

## Implementer Checklist

<!--
Fill out the checklist below as applicable to your change. Bug fixes and new features must 
check off all of the required items.
-->

N/A