### PR TITLE
GEN-1043: add OZ relayer address as a Divider trusted address on Goerli

### DIFF
--- a/pkg/deployments/deploy/prod/07-multisig_setup.js
+++ b/pkg/deployments/deploy/prod/07-multisig_setup.js
@@ -1,4 +1,4 @@
-const { SENSE_MULTISIG } = require("../../hardhat.addresses");
+const { SENSE_MULTISIG, OZ_RELAYER } = require("../../hardhat.addresses");
 const log = console.log;
 
 module.exports = async function () {
@@ -7,7 +7,7 @@ module.exports = async function () {
   const chainId = await getChainId();
 
   if (!SENSE_MULTISIG.has(chainId)) throw Error("No sense multisig found");
-  const multisig = SENSE_MULTISIG.get(chainId);
+  const multisig = chainId === "5" ? OZ_RELAYER.get(chainId) : SENSE_MULTISIG.get(chainId);
 
   const tokenHandler = await ethers.getContract("TokenHandler", signer);
   const divider = await ethers.getContract("Divider", signer);

--- a/pkg/deployments/deploy/prod/07-multisig_setup.js
+++ b/pkg/deployments/deploy/prod/07-multisig_setup.js
@@ -2,64 +2,111 @@ const { SENSE_MULTISIG, OZ_RELAYER } = require("../../hardhat.addresses");
 const log = console.log;
 
 module.exports = async function () {
-  const { deployer } = await getNamedAccounts();
-  const signer = await ethers.getSigner(deployer);
+  const { deployer, dev } = await getNamedAccounts();
+  const deployerSigner = await ethers.getSigner(deployer);
   const chainId = await getChainId();
 
   if (!SENSE_MULTISIG.has(chainId)) throw Error("No sense multisig found");
-  const multisig = chainId === "5" ? OZ_RELAYER.get(chainId) : SENSE_MULTISIG.get(chainId);
+  const multisig = chainId === "5" ? OZ_RELAYER.get("5") : SENSE_MULTISIG.get(chainId);
 
-  const tokenHandler = await ethers.getContract("TokenHandler", signer);
-  const divider = await ethers.getContract("Divider", signer);
-  const poolManager = await ethers.getContract("PoolManager", signer);
-  const spaceFactory = await ethers.getContract("SpaceFactory", signer);
-  const periphery = await ethers.getContract("Periphery", signer);
-  const emergencyStop = await ethers.getContract("EmergencyStop", signer);
+  let tokenHandler = await ethers.getContract("TokenHandler", deployerSigner);
+  let divider = await ethers.getContract("Divider", deployerSigner);
+  let poolManager = await ethers.getContract("PoolManager", deployerSigner);
+  let spaceFactory = await ethers.getContract("SpaceFactory", deployerSigner);
+  let periphery = await ethers.getContract("Periphery", deployerSigner);
+  let emergencyStop = await ethers.getContract("EmergencyStop", deployerSigner);
 
   log("\n-------------------------------------------------------");
   log("\nAdd multisig as trusted address on contracts");
 
   log("Trust the multisig address on the token handler");
-  await (await tokenHandler.setIsTrusted(multisig, true)).wait();
+  if (!(await tokenHandler.isTrusted(multisig))) {
+    await (await tokenHandler.setIsTrusted(multisig, true)).wait();
+  }
 
   log("Trust the multisig address on the divider");
-  await (await divider.setIsTrusted(multisig, true)).wait();
+  if (!(await divider.isTrusted(multisig))) {
+    await (await divider.setIsTrusted(multisig, true)).wait();
+  }
 
   log("Trust the multisig address on the pool manager");
-  await (await poolManager.setIsTrusted(multisig, true)).wait();
+  if (!(await poolManager.isTrusted(multisig))) {
+    await (await poolManager.setIsTrusted(multisig, true)).wait();
+  }
 
   log("Trust the multisig address on the space factory");
-  await (await spaceFactory.setIsTrusted(multisig, true)).wait();
+  if (!(await spaceFactory.isTrusted(multisig))) {
+    await (await spaceFactory.setIsTrusted(multisig, true)).wait();
+  }
 
   log("Trust the multisig address on the periphery");
-  await (await periphery.setIsTrusted(multisig, true)).wait();
+  if (!(await periphery.isTrusted(multisig))) {
+    await (await periphery.setIsTrusted(multisig, true)).wait();
+  }
 
   log("Trust the multisig address on the emergency stop");
-  await (await emergencyStop.setIsTrusted(multisig, true)).wait();
+  if (!(await emergencyStop.isTrusted(multisig))) {
+    await (await emergencyStop.setIsTrusted(multisig, true)).wait();
+  }
+
+  // if multisig is same as deployer, we don't want to untrust it
+  if (multisig !== deployer) {
+
+    log("\n-------------------------------------------------------");
+    log("\nRemove deployer address from trusted on contracts");
+
+    log("Untrust deployer on the token handler");
+    await (await tokenHandler.setIsTrusted(deployer, false)).wait();
+
+    log("Untrust deployer on the divider");
+    await (await divider.setIsTrusted(deployer, false)).wait();
+
+    log("Untrust deployer on the pool manager");
+    await (await poolManager.setIsTrusted(deployer, false)).wait();
+
+    log("Untrust deployer on the space factory");
+    await (await spaceFactory.setIsTrusted(deployer, false)).wait();
+
+    log("Untrust deployer on the periphery");
+    await (await periphery.setIsTrusted(deployer, false)).wait();
+
+    log("Untrust deployer on the emergency stop");
+    await (await emergencyStop.setIsTrusted(deployer, false)).wait();
+
+    log("\n-------------------------------------------------------");
+    log("Sanity checks: deployer address cannot execute trusted functions anymore...");
+
+    const calls = [
+      tokenHandler.callStatic.setIsTrusted(dev, false),
+      divider.callStatic.setIsTrusted(dev, false),
+      poolManager.callStatic.setIsTrusted(dev, false),
+      spaceFactory.callStatic.setIsTrusted(dev, false),
+      periphery.callStatic.setIsTrusted(dev, false),
+      emergencyStop.callStatic.setIsTrusted(dev, false),
+    ];
+    const res = await Promise.allSettled(calls);
+    if (res.every(r => r.status === "rejected")) {
+      log("Sanity checks: OK!");
+    } else {
+      throw Error("Sanity checks: FAILED");
+    }
+  }
 
   log("\n-------------------------------------------------------");
-  log("\nRemove deployer address from trusted on contracts");
+  log("Sanity checks: multisig address can execute trusted functions...");
 
-  log("Untrust deployer on the token handler");
-  await (await tokenHandler.setIsTrusted(deployer, false)).wait();
+  const multisigSigner = await hre.ethers.getSigner(multisig);
+  tokenHandler = tokenHandler.connect(multisigSigner);
+  divider = divider.connect(multisigSigner);
+  poolManager = poolManager.connect(multisigSigner);
+  spaceFactory = spaceFactory.connect(multisigSigner);
+  periphery = periphery.connect(multisigSigner);
+  emergencyStop = emergencyStop.connect(multisigSigner);
 
-  log("Untrust deployer on the divider");
-  await (await divider.setIsTrusted(deployer, false)).wait();
-
-  log("Untrust deployer on the pool manager");
-  await (await poolManager.setIsTrusted(deployer, false)).wait();
-
-  log("Untrust deployer on the space factory");
-  await (await spaceFactory.setIsTrusted(deployer, false)).wait();
-
-  log("Untrust deployer on the periphery");
-  await (await periphery.setIsTrusted(deployer, false)).wait();
-
-  log("Untrust deployer on the emergency stop");
-  await (await emergencyStop.setIsTrusted(deployer, false)).wait();
-
-  log("\n-------------------------------------------------------");
-  log("Sanity checks: deployer address cannot execute trusted functions anymore...");
+  await hre.network.provider.request({
+    method: "hardhat_impersonateAccount",
+    params: [multisig],
+  });
 
   const calls = [
     tokenHandler.callStatic.setIsTrusted(dev, false),
@@ -70,11 +117,12 @@ module.exports = async function () {
     emergencyStop.callStatic.setIsTrusted(dev, false),
   ];
   const res = await Promise.allSettled(calls);
-  if (res.every(r => r.status === "rejected")) {
+  if (res.every(r => r.status === "fulfilled")) {
     log("Sanity checks: OK!");
   } else {
     throw Error("Sanity checks: FAILED");
   }
+
 };
 
 module.exports.tags = ["prod:multisig", "scenario:prod"];

--- a/pkg/deployments/deploy/simulated/07-multisig_setup.js
+++ b/pkg/deployments/deploy/simulated/07-multisig_setup.js
@@ -6,8 +6,14 @@ module.exports = async function () {
   const deployerSigner = await ethers.getSigner(deployer);
   const chainId = await getChainId();
 
-  if (!SENSE_MULTISIG.has(chainId)) throw Error("No sense multisig found");
-  const multisig = chainId === "5" ? OZ_RELAYER.get("5") : SENSE_MULTISIG.get(chainId);
+  let signer;
+  if (chainId === "1") {
+    if (!SENSE_MULTISIG.has("1")) throw Error("No sense multisig found for mainnet");
+    signer = SENSE_MULTISIG.get(chainId);
+  } else {
+    if (!OZ_RELAYER.get(chainId)) throw Error(`No OZ relayer found for chain ID ${chainId}`);
+    signer = OZ_RELAYER.get("5");
+  }
 
   let tokenHandler = await ethers.getContract("TokenHandler", deployerSigner);
   let divider = await ethers.getContract("Divider", deployerSigner);
@@ -17,40 +23,40 @@ module.exports = async function () {
   let emergencyStop = await ethers.getContract("EmergencyStop", deployerSigner);
 
   log("\n-------------------------------------------------------")
-  log("\nAdd multisig as trusted address on contracts");
+  log("\nAdd signer as trusted address on contracts");
 
-  log("Trust the multisig address on the token handler");
-  if (!(await tokenHandler.isTrusted(multisig))) {
-    await (await tokenHandler.setIsTrusted(multisig, true)).wait();
+  log("Trust the signer address on the token handler");
+  if (!(await tokenHandler.isTrusted(signer))) {
+    await (await tokenHandler.setIsTrusted(signer, true)).wait();
   }
 
-  log("Trust the multisig address on the divider");
-  if (!(await divider.isTrusted(multisig))) {
-    await (await divider.setIsTrusted(multisig, true)).wait();
+  log("Trust the signer address on the divider");
+  if (!(await divider.isTrusted(signer))) {
+    await (await divider.setIsTrusted(signer, true)).wait();
   }
 
-  log("Trust the multisig address on the pool manager");
-  if (!(await poolManager.isTrusted(multisig))) {
-    await (await poolManager.setIsTrusted(multisig, true)).wait();
+  log("Trust the signer address on the pool manager");
+  if (!(await poolManager.isTrusted(signer))) {
+    await (await poolManager.setIsTrusted(signer, true)).wait();
   }
 
-  log("Trust the multisig address on the space factory");
-  if (!(await spaceFactory.isTrusted(multisig))) {
-    await (await spaceFactory.setIsTrusted(multisig, true)).wait();
+  log("Trust the signer address on the space factory");
+  if (!(await spaceFactory.isTrusted(signer))) {
+    await (await spaceFactory.setIsTrusted(signer, true)).wait();
   }
 
-  log("Trust the multisig address on the periphery");
-  if (!(await periphery.isTrusted(multisig))) {
-    await (await periphery.setIsTrusted(multisig, true)).wait();
+  log("Trust the signer address on the periphery");
+  if (!(await periphery.isTrusted(signer))) {
+    await (await periphery.setIsTrusted(signer, true)).wait();
   }
 
-  log("Trust the multisig address on the emergency stop");
-  if (!(await emergencyStop.isTrusted(multisig))) {
-    await (await emergencyStop.setIsTrusted(multisig, true)).wait();
+  log("Trust the signer address on the emergency stop");
+  if (!(await emergencyStop.isTrusted(signer))) {
+    await (await emergencyStop.setIsTrusted(signer, true)).wait();
   }
 
-  // if multisig is same as deployer, we don't want to untrust it
-  if (multisig !== deployer) {
+  // if signer is same as deployer, we don't want to untrust it
+  if (signer !== deployer) {
     log("\n-------------------------------------------------------")
     log("\nRemove deployer address from trusted on contracts");
     log("Untrust deployer on the token handler");
@@ -103,9 +109,9 @@ module.exports = async function () {
   }
 
   log("\n-------------------------------------------------------");
-  log("Sanity checks: multisig address can execute trusted functions...");
+  log("Sanity checks: signer address can execute trusted functions...");
 
-  const multisigSigner = await hre.ethers.getSigner(multisig);
+  const multisigSigner = await hre.ethers.getSigner(signer);
   tokenHandler = tokenHandler.connect(multisigSigner);
   divider = divider.connect(multisigSigner);
   poolManager = poolManager.connect(multisigSigner);
@@ -115,7 +121,7 @@ module.exports = async function () {
 
   await hre.network.provider.request({
     method: "hardhat_impersonateAccount",
-    params: [multisig],
+    params: [signer],
   });
 
   const calls = [
@@ -135,5 +141,5 @@ module.exports = async function () {
 
 };
 
-module.exports.tags = ["simulated:multisig", "scenario:simulated"];
+module.exports.tags = ["simulated:signer", "scenario:simulated"];
 module.exports.dependencies = ["simulated:series"];

--- a/pkg/deployments/deploy/simulated/07-multisig_setup.js
+++ b/pkg/deployments/deploy/simulated/07-multisig_setup.js
@@ -3,18 +3,18 @@ const log = console.log;
 
 module.exports = async function () {
   const { deployer, dev } = await getNamedAccounts();
-  const signer = await ethers.getSigner(deployer);
+  const deployerSigner = await ethers.getSigner(deployer);
   const chainId = await getChainId();
 
   if (!SENSE_MULTISIG.has(chainId)) throw Error("No sense multisig found");
-  const multisig = chainId === "5" ? OZ_RELAYER.get(chainId) : SENSE_MULTISIG.get(chainId);
+  const multisig = chainId === "5" ? OZ_RELAYER.get("5") : SENSE_MULTISIG.get(chainId);
 
-  const tokenHandler = await ethers.getContract("TokenHandler", signer);
-  const divider = await ethers.getContract("Divider", signer);
-  const poolManager = await ethers.getContract("PoolManager", signer);
-  const spaceFactory = await ethers.getContract("SpaceFactory", signer);
-  const periphery = await ethers.getContract("Periphery", signer);
-  const emergencyStop = await ethers.getContract("EmergencyStop", signer);
+  let tokenHandler = await ethers.getContract("TokenHandler", deployerSigner);
+  let divider = await ethers.getContract("Divider", deployerSigner);
+  let poolManager = await ethers.getContract("PoolManager", deployerSigner);
+  let spaceFactory = await ethers.getContract("SpaceFactory", deployerSigner);
+  let periphery = await ethers.getContract("Periphery", deployerSigner);
+  let emergencyStop = await ethers.getContract("EmergencyStop", deployerSigner);
 
   log("\n-------------------------------------------------------")
   log("\nAdd multisig as trusted address on contracts");
@@ -49,41 +49,74 @@ module.exports = async function () {
     await (await emergencyStop.setIsTrusted(multisig, true)).wait();
   }
 
-  log("\n-------------------------------------------------------")
-  log("\nRemove deployer address from trusted on contracts");
+  // if multisig is same as deployer, we don't want to untrust it
+  if (multisig !== deployer) {
+    log("\n-------------------------------------------------------")
+    log("\nRemove deployer address from trusted on contracts");
+    log("Untrust deployer on the token handler");
+    if (await tokenHandler.isTrusted(deployer)) {
+      await (await tokenHandler.setIsTrusted(deployer, false)).wait();  
+    }
 
-  log("Untrust deployer on the token handler");
-  if (await tokenHandler.isTrusted(deployer)) {
-    await (await tokenHandler.setIsTrusted(deployer, false)).wait();  
+    log("Untrust deployer on the divider");
+    if (await divider.isTrusted(deployer)) {
+      await (await divider.setIsTrusted(deployer, false)).wait();  
+    }
+
+    log("Untrust deployer on the pool manager");
+    if (await poolManager.isTrusted(deployer)) {
+      await (await poolManager.setIsTrusted(deployer, false)).wait();  
+    }
+
+    log("Untrust deployer on the space factory");
+    if (await spaceFactory.isTrusted(deployer)) {
+      await (await spaceFactory.setIsTrusted(deployer, false)).wait();  
+    }
+
+    log("Untrust deployer on the periphery");
+    if (await periphery.isTrusted(deployer)) {
+      await (await periphery.setIsTrusted(deployer, false)).wait();  
+    }
+
+    log("Untrust deployer on the emergency stop");
+    if (await emergencyStop.isTrusted(deployer)) {
+      await (await emergencyStop.setIsTrusted(deployer, false)).wait();  
+    }
+
+    log("\n-------------------------------------------------------")
+    log("\Sanity checks: checking deployer address cannot execute trusted functions anymore...");
+
+    const calls = [
+      tokenHandler.callStatic.setIsTrusted(dev, false),
+      divider.callStatic.setIsTrusted(dev, false),
+      poolManager.callStatic.setIsTrusted(dev, false),
+      spaceFactory.callStatic.setIsTrusted(dev, false),
+      periphery.callStatic.setIsTrusted(dev, false),
+      emergencyStop.callStatic.setIsTrusted(dev, false),
+    ];
+    const res = await Promise.allSettled(calls);
+    if (res.every(r => r.status === 'rejected')) {
+      log("\Sanity checks: OK!");
+    } else {
+      throw Error('Sanity checks: FAILED');
+    }
   }
 
-  log("Untrust deployer on the divider");
-  if (await divider.isTrusted(deployer)) {
-    await (await divider.setIsTrusted(deployer, false)).wait();  
-  }
+  log("\n-------------------------------------------------------");
+  log("Sanity checks: multisig address can execute trusted functions...");
 
-  log("Untrust deployer on the pool manager");
-  if (await poolManager.isTrusted(deployer)) {
-    await (await poolManager.setIsTrusted(deployer, false)).wait();  
-  }
+  const multisigSigner = await hre.ethers.getSigner(multisig);
+  tokenHandler = tokenHandler.connect(multisigSigner);
+  divider = divider.connect(multisigSigner);
+  poolManager = poolManager.connect(multisigSigner);
+  spaceFactory = spaceFactory.connect(multisigSigner);
+  periphery = periphery.connect(multisigSigner);
+  emergencyStop = emergencyStop.connect(multisigSigner);
 
-  log("Untrust deployer on the space factory");
-  if (await spaceFactory.isTrusted(deployer)) {
-    await (await spaceFactory.setIsTrusted(deployer, false)).wait();  
-  }
-
-  log("Untrust deployer on the periphery");
-  if (await periphery.isTrusted(deployer)) {
-    await (await periphery.setIsTrusted(deployer, false)).wait();  
-  }
-
-  log("Untrust deployer on the emergency stop");
-  if (await emergencyStop.isTrusted(deployer)) {
-    await (await emergencyStop.setIsTrusted(deployer, false)).wait();  
-  }
-
-  log("\n-------------------------------------------------------")
-  log("\Sanity checks: checking deployer address cannot execute trusted functions anymore...");
+  await hre.network.provider.request({
+    method: "hardhat_impersonateAccount",
+    params: [multisig],
+  });
 
   const calls = [
     tokenHandler.callStatic.setIsTrusted(dev, false),
@@ -94,10 +127,10 @@ module.exports = async function () {
     emergencyStop.callStatic.setIsTrusted(dev, false),
   ];
   const res = await Promise.allSettled(calls);
-  if (res.every(r => r.status === 'rejected')) {
-    log("\Sanity checks: OK!");
+  if (res.every(r => r.status === "fulfilled")) {
+    log("Sanity checks: OK!");
   } else {
-    throw Error('Sanity checks: FAILED');
+    throw Error("Sanity checks: FAILED");
   }
 
 };

--- a/pkg/deployments/deploy/simulated/07-multisig_setup.js
+++ b/pkg/deployments/deploy/simulated/07-multisig_setup.js
@@ -1,4 +1,4 @@
-const { SENSE_MULTISIG } = require("../../hardhat.addresses");
+const { SENSE_MULTISIG, OZ_RELAYER } = require("../../hardhat.addresses");
 const log = console.log;
 
 module.exports = async function () {
@@ -7,7 +7,7 @@ module.exports = async function () {
   const chainId = await getChainId();
 
   if (!SENSE_MULTISIG.has(chainId)) throw Error("No sense multisig found");
-  const multisig = SENSE_MULTISIG.get(chainId);
+  const multisig = chainId === "5" ? OZ_RELAYER.get(chainId) : SENSE_MULTISIG.get(chainId);
 
   const tokenHandler = await ethers.getContract("TokenHandler", signer);
   const divider = await ethers.getContract("Divider", signer);


### PR DESCRIPTION
## Motivation

When deploying to Goerli, we remove the deployer address from the trusted addresses for the Divider but we are not adding any other address.

Therefore, there's no way to pause the divider. We can call the emergency stop but that will not pause the divider (it will only set the permissionless mode to false and pause all the adapters passed in the args). 

## Solution

Set an address, different to the deployer's address, as trusted for the Divider on Goerli.  

## Implementer Checklist

N/A