### PR TITLE
GEN-1233: wsteth with steth as underlying

### DIFF
--- a/justfile
+++ b/justfile
@@ -129,6 +129,9 @@ _forge_mock_target_decimals:
 _forge_mock_underlying_decimals:
     @printf {{ FORGE_MOCK_UNDERLYING_DECIMALS }}
 
+_forge_rpc_url:
+    @printf {{ MAINNET_RPC }}
+
 remappings-from-pkg-deps := ```
     cat pkg/*/package.json  |
     jq 'select(.dependencies != null) | .dependencies | to_entries | map([.key + "/", "../../node_modules/" + .key + "/"] | join("="))' |

--- a/pkg/core/foundry.toml
+++ b/pkg/core/foundry.toml
@@ -1,11 +1,9 @@
-[default]
+[profile.default]
 root = "."
 libs = ['../../node_modules/', '../../']
 tests = "./src/tests"
 ffi = true
 verbosity = 3
-# Fork block mined on Apr 18 2022 at 12:00:10 AM UTC
-fork_block_number = 14605885
 remappings = [
     '@sense-finance/v1-utils=../utils',
     '@sense-finance/v1-core=./',

--- a/pkg/core/src/adapters/implementations/lido/WstETHAdapter.sol
+++ b/pkg/core/src/adapters/implementations/lido/WstETHAdapter.sol
@@ -11,57 +11,29 @@ import { SafeTransferLib } from "@rari-capital/solmate/src/utils/SafeTransferLib
 import { Errors } from "@sense-finance/v1-utils/src/libs/Errors.sol";
 
 interface WstETHLike {
-    /// @notice https://github.com/lidofinance/lido-dao/blob/master/contracts/0.6.12/WstETH.sol
-    /// @dev returns the current exchange rate of stETH to wstETH in wei (18 decimals)
-    function stEthPerToken() external view returns (uint256);
-
+    /// @notice Exchanges wstETH to stETH
     function unwrap(uint256 _wstETHAmount) external returns (uint256);
 
+    /// @notice Exchanges stETH to wstETH
     function wrap(uint256 _stETHAmount) external returns (uint256);
 }
 
 interface StETHLike {
-    /// @notice Send funds to the pool with optional _referral parameter
-    /// @dev This function is alternative way to submit funds. Supports optional referral address.
-    /// @return Amount of StETH shares generated
-    function submit(address _referral) external payable returns (uint256);
-
-    /// @return the amount of tokens owned by the `_account`.
-    ///
-    /// @dev Balances are dynamic and equal the `_account`'s share in the amount of the
-    /// total Ether controlled by the protocol. See `sharesOf`.
+    /// @notice Get amount of stETH for a one wstETH
     function getPooledEthByShares(uint256 _sharesAmount) external view returns (uint256);
-
-    ///@return the amount of tokens owned by the `_account`.
-    ///
-    ///@dev Balances are dynamic and equal the `_account`'s share in the amount of the
-    ///total Ether controlled by the protocol. See `sharesOf`.
-    function balanceOf(address _account) external view returns (uint256);
 }
 
-interface CurveStableSwapLike {
-    function get_dy(
-        int128 i,
-        int128 j,
-        uint256 dx
-    ) external view returns (uint256);
-
-    function exchange(
-        int128 i,
-        int128 j,
-        uint256 dx,
-        uint256 min_dy
-    ) external payable returns (uint256);
-}
-
-interface WETHLike {
-    function deposit() external payable;
-
-    function withdraw(uint256 wad) external;
-}
-
-interface StEthPriceFeedLike {
-    function safe_price_value() external view returns (uint256);
+interface PriceOracleLike {
+    function latestRoundData()
+        external
+        view
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        );
 }
 
 /// @notice Adapter contract for wstETH
@@ -69,17 +41,10 @@ contract WstETHAdapter is BaseAdapter {
     using FixedMath for uint256;
     using SafeTransferLib for ERC20;
 
-    address public constant CETH = 0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5;
-    address public constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
     address public constant WSTETH = 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0;
     address public constant STETH = 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84;
-    address public constant CURVESINGLESWAP = 0xDC24316b9AE028F1497c275EB9192a3Ea0f67022;
-    address public constant STETHPRICEFEED = 0xAb55Bf4DfBf469ebfe082b7872557D1F87692Fe6;
-
-    // On 2022.02.28, a swap from 100k stETH ($250m+ worth) to ETH was quoted
-    // by https://curve.fi/steth to incur 0.39% slippage, so we went with 0.5%
-    // to capture practically all unwrap/wrap sizes through the Sense adapter."
-    uint256 public constant SLIPPAGE_TOLERANCE = 0.005e18;
+    address public constant STETH_USD_PRICEFEED = 0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8; // Chainlink stETH-USD price feed
+    address public constant ETH_USD_PRICEFEED = 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419; // Chainlink ETH-USD price feed
 
     /// @notice Cached scale value from the last call to `scale()`
     uint256 public override scaleStored;
@@ -93,15 +58,13 @@ contract WstETHAdapter is BaseAdapter {
     ) BaseAdapter(_divider, _target, _underlying, _ifee, _adapterParams) {
         // approve wstETH contract to pull stETH (used on wrapUnderlying())
         ERC20(STETH).approve(WSTETH, type(uint256).max);
-        // approve Curve stETH/ETH pool to pull stETH (used on unwrapTarget())
-        ERC20(STETH).approve(CURVESINGLESWAP, type(uint256).max);
         // set an inital cached scale value
-        scaleStored = _wstEthToEthRate();
+        scaleStored = StETHLike(STETH).getPooledEthByShares(1 ether);
     }
 
     /// @return exRate Eth per wstEtH (natively in 18 decimals)
     function scale() external virtual override returns (uint256 exRate) {
-        exRate = _wstEthToEthRate();
+        exRate = StETHLike(STETH).getPooledEthByShares(1 ether);
 
         if (exRate != scaleStored) {
             // update value only if different than the previous
@@ -109,51 +72,25 @@ contract WstETHAdapter is BaseAdapter {
         }
     }
 
-    function getUnderlyingPrice() external pure override returns (uint256 price) {
-        price = 1e18;
+    /// @dev To calculate stETH-ETH price we use Chainlink's stETH-USD and ETH-USD price feeds.
+    function getUnderlyingPrice() external view override returns (uint256 price) {
+        (, int256 stethPrice, , uint256 stethUpdatedAt, ) = PriceOracleLike(STETH_USD_PRICEFEED).latestRoundData();
+        (, int256 ethPrice, , uint256 ethUpdatedAt, ) = PriceOracleLike(ETH_USD_PRICEFEED).latestRoundData();
+        if (block.timestamp - stethUpdatedAt > 1 hours) revert Errors.InvalidPrice();
+        if (block.timestamp - ethUpdatedAt > 1 hours) revert Errors.InvalidPrice();
+        price = uint256(stethPrice).fdiv(uint256(ethPrice));
+        if (price < 0) revert Errors.InvalidPrice();
     }
 
-    function unwrapTarget(uint256 amount) external override returns (uint256 eth) {
+    function unwrapTarget(uint256 amount) external override returns (uint256 stETH) {
         ERC20(WSTETH).safeTransferFrom(msg.sender, address(this), amount); // pull wstETH
-        uint256 stEth = WstETHLike(WSTETH).unwrap(amount); // unwrap wstETH into stETH
-
-        // exchange stETH to ETH exchange on Curve
-        // to calculate the minDy, we use Lido's safe_price_value() which should prevent from flash loan / sandwhich attacks
-        // and we are also adding a slippage tolerance of 0.5%
-        uint256 stEthEth = StEthPriceFeedLike(STETHPRICEFEED).safe_price_value(); // returns the cached stETH/ETH safe price
-
-        eth = CurveStableSwapLike(CURVESINGLESWAP).exchange(
-            int128(1),
-            int128(0),
-            stEth,
-            stEthEth.fmul(stEth).fmul(FixedMath.WAD - SLIPPAGE_TOLERANCE)
-        );
-
-        // deposit ETH into WETH contract
-        (bool success, ) = WETH.call{ value: eth }("");
-        if (!success) revert Errors.TransferFailed();
-
-        ERC20(WETH).safeTransfer(msg.sender, eth); // transfer WETH back to sender (periphery)
+        // unwrap wstETH into stETH and transfer it back to sender
+        ERC20(STETH).safeTransfer(msg.sender, stETH = WstETHLike(WSTETH).unwrap(amount));
     }
 
     function wrapUnderlying(uint256 amount) external override returns (uint256 wstETH) {
-        ERC20(WETH).safeTransferFrom(msg.sender, address(this), amount); // pull WETH
-        WETHLike(WETH).withdraw(amount); // unwrap WETH into ETH
-        StETHLike(STETH).submit{ value: amount }(address(0)); // stake ETH (returns wstETH)
-        uint256 stEth = StETHLike(STETH).balanceOf(address(this));
-        ERC20(WSTETH).safeTransfer(msg.sender, wstETH = WstETHLike(WSTETH).wrap(stEth)); // transfer wstETH to msg.sender
-    }
-
-    function _wstEthToEthRate() internal view returns (uint256 exRate) {
-        // In order to account for the stETH/ETH CurveStableSwap rate,
-        // we use `safe_price_value` from Lido's stETH price feed.
-        // https://docs.lido.fi/contracts/steth-price-feed#steth-price-feed-specification
-        uint256 stEthEth = StEthPriceFeedLike(STETHPRICEFEED).safe_price_value(); // returns the cached stETH/ETH safe price
-        uint256 wstETHstETH = StETHLike(STETH).getPooledEthByShares(1 ether); // stETH tokens per one wstETH
-        exRate = stEthEth.fmul(wstETHstETH);
-    }
-
-    fallback() external payable {
-        if (msg.sender != WETH && msg.sender != CURVESINGLESWAP) revert Errors.SenderNotEligible();
+        ERC20(STETH).safeTransferFrom(msg.sender, address(this), amount); // pull STETH
+        // wrap stETH into wstETH and transfer it back to sender
+        ERC20(WSTETH).safeTransfer(msg.sender, wstETH = WstETHLike(WSTETH).wrap(amount));
     }
 }

--- a/pkg/core/src/tests/adapters/FAdapter.tm.sol
+++ b/pkg/core/src/tests/adapters/FAdapter.tm.sol
@@ -43,7 +43,20 @@ contract FAdapterTestHelper is LiquidityHelper, DSTest {
 
     Hevm internal constant hevm = Hevm(HEVM_ADDRESS);
 
+    uint256 public mainnetFork;
+
     function setUp() public {
+        // Get RPC url from the environment
+        string[] memory inputs = new string[](2);
+        inputs[0] = "just";
+        inputs[1] = "_forge_rpc_url";
+        string memory rpcUrl = hevm.envString("MAINNET_RPC");
+
+        // Create fork from block mined on Apr 18 2022 at 12:00:10 AM UTC
+        // (before Fuse bug)
+        mainnetFork = hevm.createFork(rpcUrl, 14605885);
+        hevm.selectFork(mainnetFork);
+
         giveTokens(AddressBook.DAI, ONE_FTOKEN, hevm);
         giveTokens(AddressBook.f18DAI, ONE_FTOKEN, hevm);
         giveTokens(AddressBook.WETH, ONE_FTOKEN, hevm);

--- a/pkg/core/src/tests/adapters/WstETHAdapter.tm.sol
+++ b/pkg/core/src/tests/adapters/WstETHAdapter.tm.sol
@@ -8,7 +8,7 @@ import { SafeTransferLib } from "@rari-capital/solmate/src/utils/SafeTransferLib
 // Internal references
 import { Periphery } from "../../Periphery.sol";
 import { Divider, TokenHandler } from "../../Divider.sol";
-import { WstETHAdapter } from "../../adapters/implementations/lido/WstETHAdapter.sol";
+import { WstETHAdapter, StETHLike } from "../../adapters/implementations/lido/WstETHAdapter.sol";
 import { BaseAdapter } from "../../adapters/abstract/BaseAdapter.sol";
 import { Errors } from "@sense-finance/v1-utils/src/libs/Errors.sol";
 
@@ -19,39 +19,42 @@ import { Hevm } from "../test-helpers/Hevm.sol";
 import { DateTimeFull } from "../test-helpers/DateTimeFull.sol";
 import { LiquidityHelper } from "../test-helpers/LiquidityHelper.sol";
 
-interface ICurveStableSwap {
+interface PriceOracleLike {
+    function latestRoundData()
+        external
+        view
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        );
+
+    function getRoundData(uint80 _roundId)
+        external
+        view
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        );
+
+    function latestRound() external view returns (uint256 round);
+}
+
+interface CurveStableSwapLike {
     function get_dy(
         int128 i,
         int128 j,
         uint256 dx
     ) external view returns (uint256);
-
-    function exchange(
-        int128 i,
-        int128 j,
-        uint256 dx,
-        uint256 min_dy
-    ) external payable returns (uint256);
-}
-
-interface StETHInterface {
-    function getSharesByPooledEth(uint256 _ethAmount) external returns (uint256);
-
-    function balanceOf(address owner) external returns (uint256);
-}
-
-interface WstETHInterface {
-    function stEthPerToken() external view returns (uint256);
-
-    function getWstETHByStETH(uint256 _stETHAmount) external returns (uint256);
-}
-
-interface StEthPriceFeed {
-    function safe_price_value() external returns (uint256);
 }
 
 contract WstETHAdapterTestHelper is LiquidityHelper, DSTest {
-    WstETHAdapter adapter;
+    WstETHAdapter internal adapter;
     Divider internal divider;
     Periphery internal periphery;
     TokenHandler internal tokenHandler;
@@ -64,6 +67,8 @@ contract WstETHAdapterTestHelper is LiquidityHelper, DSTest {
     uint16 public constant DEFAULT_MODE = 0;
     uint64 public constant DEFAULT_TILT = 0;
 
+    Hevm internal constant hevm = Hevm(HEVM_ADDRESS);
+
     function setUp() public {
         address[] memory assets = new address[](1);
         assets[0] = AddressBook.WSTETH;
@@ -74,7 +79,7 @@ contract WstETHAdapterTestHelper is LiquidityHelper, DSTest {
         tokenHandler.init(address(divider));
 
         BaseAdapter.AdapterParams memory adapterParams = BaseAdapter.AdapterParams({
-            oracle: AddressBook.RARI_ORACLE,
+            oracle: address(0),
             stake: AddressBook.DAI,
             stakeSize: STAKE_SIZE,
             minm: MIN_MATURITY,
@@ -86,7 +91,7 @@ contract WstETHAdapterTestHelper is LiquidityHelper, DSTest {
         adapter = new WstETHAdapter(
             address(divider),
             AddressBook.WSTETH,
-            AddressBook.WETH,
+            AddressBook.STETH,
             ISSUANCE_FEE,
             adapterParams
         ); // wstETH adapter
@@ -102,76 +107,81 @@ contract WstETHAdapters is WstETHAdapterTestHelper {
     using FixedMath for uint256;
 
     function testMainnetWstETHAdapterScale() public {
-        uint256 ethStEth = StEthPriceFeed(AddressBook.STETHPRICEFEED).safe_price_value();
-        uint256 wstETHstETH = WstETHInterface(AddressBook.WSTETH).stEthPerToken();
+        uint256 wstETHstETH = StETHLike(AddressBook.STETH).getPooledEthByShares(1 ether);
+        assertEq(adapter.scale(), wstETHstETH);
+    }
 
-        uint256 scale = ethStEth.fmul(wstETHstETH);
-        assertEq(adapter.scale(), scale);
+    function testMainnetWstETHAdapterPriceFeedIsValid() public {
+        // Check last updated timestamp is less than 1 hour old
+        (, int256 stethPrice, , uint256 stethUpdatedAt, ) = PriceOracleLike(adapter.STETH_USD_PRICEFEED())
+            .latestRoundData();
+        (, int256 ethPrice, , uint256 ethUpdatedAt, ) = PriceOracleLike(adapter.ETH_USD_PRICEFEED()).latestRoundData();
+        assertTrue(block.timestamp - stethUpdatedAt < 1 hours);
+        assertTrue(block.timestamp - ethUpdatedAt < 1 hours);
     }
 
     function testMainnetGetUnderlyingPrice() public {
-        uint256 price = 1e18;
-        assertEq(adapter.getUnderlyingPrice(), price);
+        (, int256 stethPrice, , uint256 stethUpdatedAt, ) = PriceOracleLike(adapter.STETH_USD_PRICEFEED())
+            .latestRoundData();
+        (, int256 ethPrice, , uint256 ethUpdatedAt, ) = PriceOracleLike(adapter.ETH_USD_PRICEFEED()).latestRoundData();
+
+        uint256 curvePrice = CurveStableSwapLike(AddressBook.STETH_POOL).get_dy(int128(1), int128(0), 1e18);
+
+        // within 5%
+        uint256 stEthEthPrice = uint256(stethPrice).fdiv(uint256(ethPrice));
+        assertClose(stEthEthPrice, curvePrice, stEthEthPrice.fmul(0.050e18));
+        assertEq(adapter.getUnderlyingPrice(), uint256(stEthEthPrice));
     }
 
     function testMainnetUnwrapTarget() public {
-        uint256 wethBalanceBefore = ERC20(AddressBook.WETH).balanceOf(address(this));
-        uint256 wstETHBalanceBefore = ERC20(AddressBook.WSTETH).balanceOf(address(this));
-        ERC20(AddressBook.WSTETH).approve(address(adapter), wstETHBalanceBefore);
-        uint256 minDy = ICurveStableSwap(AddressBook.CURVESINGLESWAP).get_dy(
-            int128(1),
-            int128(0),
-            wstETHBalanceBefore.fmul(adapter.scale())
-        );
-        adapter.unwrapTarget(wstETHBalanceBefore);
-        uint256 wstETHBalanceAfter = ERC20(AddressBook.WSTETH).balanceOf(address(this));
-        uint256 wethBalanceAfter = ERC20(AddressBook.WETH).balanceOf(address(this));
+        uint256 uBalanceBefore = ERC20(AddressBook.STETH).balanceOf(address(this));
+        uint256 tBalanceBefore = ERC20(AddressBook.WSTETH).balanceOf(address(this));
 
-        assertEq(wstETHBalanceAfter, 0);
-        // Received at least the min expected from the curve exchange rate
-        assertGt(wethBalanceAfter, wethBalanceBefore + minDy);
-        // Unwraps close to what scale suggests it should
-        assertClose(
-            wethBalanceAfter,
-            wethBalanceBefore + wstETHBalanceBefore.fmul(adapter.scale()),
-            wethBalanceBefore.fmul(adapter.SLIPPAGE_TOLERANCE())
-        );
+        ERC20(AddressBook.WSTETH).approve(address(adapter), tBalanceBefore);
+        uint256 rate = StETHLike(AddressBook.STETH).getPooledEthByShares(1 ether);
+        uint256 uDecimals = ERC20(AddressBook.STETH).decimals();
+
+        uint256 unwrapped = tBalanceBefore.fmulUp(rate, 10**uDecimals);
+        adapter.unwrapTarget(tBalanceBefore);
+
+        uint256 tBalanceAfter = ERC20(AddressBook.WSTETH).balanceOf(address(this));
+        uint256 uBalanceAfter = ERC20(AddressBook.STETH).balanceOf(address(this));
+
+        assertEq(tBalanceAfter, 0);
+        assertClose(uBalanceBefore + unwrapped, uBalanceAfter);
     }
 
     function testMainnetWrapUnderlying() public {
-        uint256 wethBalanceBefore = ERC20(AddressBook.WETH).balanceOf(address(this));
-        uint256 stEthBalanceBefore = ERC20(AddressBook.STETH).balanceOf(address(this));
-        uint256 wstETHBalanceBefore = ERC20(AddressBook.WSTETH).balanceOf(address(this));
+        uint256 uBalanceBefore = ERC20(AddressBook.STETH).balanceOf(address(this));
+        uint256 tBalanceBefore = ERC20(AddressBook.WSTETH).balanceOf(address(this));
 
-        ERC20(AddressBook.WETH).approve(address(adapter), wethBalanceBefore);
-        uint256 wstETH = WstETHInterface(AddressBook.WSTETH).getWstETHByStETH(wethBalanceBefore);
-        adapter.wrapUnderlying(wethBalanceBefore);
-        uint256 wstETHBalanceAfter = ERC20(AddressBook.WSTETH).balanceOf(address(this));
-        uint256 wethBalanceAfter = ERC20(AddressBook.WETH).balanceOf(address(this));
-        uint256 stEthBalanceAfter = ERC20(AddressBook.STETH).balanceOf(address(this));
-        assertEq(stEthBalanceAfter, stEthBalanceBefore);
-        assertEq(wethBalanceAfter, 0);
-        assertClose(wstETHBalanceBefore + wstETH, wstETHBalanceAfter);
+        ERC20(AddressBook.STETH).approve(address(adapter), uBalanceBefore);
+        uint256 rate = StETHLike(AddressBook.STETH).getPooledEthByShares(1 ether);
+        uint256 uDecimals = ERC20(AddressBook.STETH).decimals();
+
+        uint256 wrapped = uBalanceBefore.fdiv(rate, 10**uDecimals);
+        adapter.wrapUnderlying(uBalanceBefore);
+
+        uint256 tBalanceAfter = ERC20(AddressBook.WSTETH).balanceOf(address(this));
+        uint256 uBalanceAfter = ERC20(AddressBook.STETH).balanceOf(address(this));
+
+        assertClose(uBalanceAfter, 0);
+        assertEq(tBalanceBefore + wrapped, tBalanceAfter);
     }
 
     function testMainnetWrapUnwrap(uint64 wrapAmt) public {
-        uint256 prebal = ERC20(AddressBook.WETH).balanceOf(address(this));
+        uint256 prebal = ERC20(AddressBook.STETH).balanceOf(address(this));
         if (wrapAmt > prebal || wrapAmt < 1e4) return;
 
         // Approvals
-        ERC20(AddressBook.WETH).approve(address(adapter), type(uint256).max);
+        ERC20(AddressBook.STETH).approve(address(adapter), type(uint256).max);
         ERC20(AddressBook.WSTETH).approve(address(adapter), type(uint256).max);
 
         // Full cycle
         adapter.unwrapTarget(adapter.wrapUnderlying(wrapAmt));
-        uint256 postbal = ERC20(AddressBook.WETH).balanceOf(address(this));
+        uint256 postbal = ERC20(AddressBook.STETH).balanceOf(address(this));
 
-        // within .1%
-        assertClose(prebal, postbal, prebal.fmul(0.001e18));
-    }
-
-    function testMainnetCantSendEtherIfNotEligible() public {
-        Hevm(HEVM_ADDRESS).expectRevert(abi.encodeWithSelector(Errors.SenderNotEligible.selector));
-        payable(address(adapter)).call{ value: 1 ether }("");
+        // When wrapping and then unwrapping on Lido we end up with 1 wei less.
+        assertClose(prebal, postbal, 1);
     }
 }

--- a/pkg/core/src/tests/test-helpers/AddressBook.sol
+++ b/pkg/core/src/tests/test-helpers/AddressBook.sol
@@ -23,12 +23,16 @@ library AddressBook {
     address public constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
 
     // protocols
-    address public constant COMPOUND_PRICE_FEED = 0x6D2299C48a8dD07a872FDd0F8233924872Ad1071;
-    address public constant RARI_ORACLE = 0x1887118E49e0F4A78Bd71B792a49dE03504A764D; // rari's oracle
-    address public constant CURVESINGLESWAP = 0xDC24316b9AE028F1497c275EB9192a3Ea0f67022;
+    address public constant STETH_POOL = 0xDC24316b9AE028F1497c275EB9192a3Ea0f67022;
     address public constant UNISWAP_ROUTER = 0xE592427A0AEce92De3Edee1F18E0157C05861564;
-    address public constant STETHPRICEFEED = 0xAb55Bf4DfBf469ebfe082b7872557D1F87692Fe6;
     address public constant COMPTROLLER = 0x3d9819210A31b4961b30EF54bE2aeD79B9c9Cd3B;
+
+    // price feeds
+    address public constant COMPOUND_PRICE_FEED = 0x6D2299C48a8dD07a872FDd0F8233924872Ad1071; // compound
+    address public constant RARI_ORACLE = 0x1887118E49e0F4A78Bd71B792a49dE03504A764D; // rari
+    address public constant MASTER_PRICE_ORACLE = 0x54Bd48678fdC1Ec2EF832C2d80030E94118CCb4B;
+    address public constant STETH_USD_PRICEFEED = 0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8; // Chainlink stETH-USD price feed
+    address public constant ETH_USD_PRICEFEED = 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419; // Chainlink ETH-USD price feed
 
     // deployed sense contract
     address public constant SPACE_FACTORY_1_2_0 = 0x984682770f1EED90C00cd57B06b151EC12e7c51C;
@@ -41,7 +45,6 @@ library AddressBook {
 
     // fuse
     address public constant JUMP_RATE_MODEL = 0xEDE47399e2aA8f076d40DC52896331CBa8bd40f7;
-    address public constant MASTER_PRICE_ORACLE = 0x54Bd48678fdC1Ec2EF832C2d80030E94118CCb4B;
 
     // fuse f18 olympus pool party
     address public constant OLYMPUS_POOL_PARTY = 0x621579DD26774022F33147D3852ef4E00024b763; // olympus pool party

--- a/pkg/core/src/tests/test-helpers/Hevm.sol
+++ b/pkg/core/src/tests/test-helpers/Hevm.sol
@@ -85,4 +85,45 @@ abstract contract Hevm {
 
     // If the condition is false, discard this run's fuzz inputs and generate new ones
     function assume(bool) external virtual;
+
+    // Creates a new fork with the given endpoint and block and returns the identifier of the fork
+    function createFork(string calldata urlOrAlias, uint256 block) external virtual returns (uint256);
+
+    // Creates a new fork with the given endpoint and the _latest_ block and returns the identifier of the fork
+    function createFork(string calldata urlOrAlias) external virtual returns (uint256);
+
+    // Creates _and_ also selects a new fork with the given endpoint and block and returns the identifier of the fork
+    function createSelectFork(string calldata urlOrAlias, uint256 block) external virtual returns (uint256);
+
+    // Creates _and_ also selects a new fork with the given endpoint and the latest block and returns the identifier of the fork
+    function createSelectFork(string calldata urlOrAlias) external virtual returns (uint256);
+
+    // Takes a fork identifier created by `createFork` and sets the corresponding forked state as active.
+    function selectFork(uint256 forkId) external virtual;
+
+    /// Returns the currently active fork
+    /// Reverts if no fork is currently active
+    function activeFork() external virtual returns (uint256);
+
+    // Updates the currently active fork to given block number
+    // This is similar to `roll` but for the currently active fork
+    function rollFork(uint256) external virtual;
+
+    // Updates the given fork to given block number
+    function rollFork(uint256 forkId, uint256 blockNumber) external virtual;
+
+    // Read environment variables, (name) => (value)
+    function envBool(string calldata) external virtual returns (bool);
+
+    function envUint(string calldata) external virtual returns (uint256);
+
+    function envInt(string calldata) external virtual returns (int256);
+
+    function envAddress(string calldata) external virtual returns (address);
+
+    function envBytes32(string calldata) external virtual returns (bytes32);
+
+    function envString(string calldata) external virtual returns (string memory);
+
+    function envBytes(string calldata) external virtual returns (bytes memory);
 }

--- a/pkg/deployments/tasks/20220720-wsteth-adapter/abi/Divider.json
+++ b/pkg/deployments/tasks/20220720-wsteth-adapter/abi/Divider.json
@@ -1,0 +1,1181 @@
+[
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_cup",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_tokenHandler",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [],
+      "name": "AlreadySettled",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "CollectNotSettled",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "CombineRestricted",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "DuplicateSeries",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ExistingValue",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "GuardCapReached",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidAdapter",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidMaturity",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "IssuanceFeeCapExceeded",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "IssuanceRestricted",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "IssueOnSettle",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "NotSettled",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OnlyPeriphery",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OnlyPermissionless",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OnlyYT",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OutOfWindowBoundaries",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "RedeemRestricted",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "SeriesDoesNotExist",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "id",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "bool",
+          "name": "isOn",
+          "type": "bool"
+        }
+      ],
+      "name": "AdapterChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "mscale",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address[]",
+          "name": "_usrs",
+          "type": "address[]"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256[]",
+          "name": "_lscales",
+          "type": "uint256[]"
+        }
+      ],
+      "name": "Backfilled",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "collected",
+          "type": "uint256"
+        }
+      ],
+      "name": "Collected",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "balance",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "Combined",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "cap",
+          "type": "uint256"
+        }
+      ],
+      "name": "GuardChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bool",
+          "name": "guarded",
+          "type": "bool"
+        }
+      ],
+      "name": "GuardedChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "balance",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "Issued",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "Paused",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "periphery",
+          "type": "address"
+        }
+      ],
+      "name": "PeripheryChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bool",
+          "name": "permissionless",
+          "type": "bool"
+        }
+      ],
+      "name": "PermissionlessChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "redeemed",
+          "type": "uint256"
+        }
+      ],
+      "name": "PrincipalRedeemed",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "pt",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "yt",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sponsor",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "target",
+          "type": "address"
+        }
+      ],
+      "name": "SeriesInitialized",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "settler",
+          "type": "address"
+        }
+      ],
+      "name": "SeriesSettled",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "Unpaused",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "trusted",
+          "type": "bool"
+        }
+      ],
+      "name": "UserTrustUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "redeemed",
+          "type": "uint256"
+        }
+      ],
+      "name": "YTRedeemed",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "ISSUANCE_FEE_CAP",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SETTLEMENT_WINDOW",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SPONSOR_WINDOW",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "adapterAddresses",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "adapterCounter",
+      "outputs": [
+        {
+          "internalType": "uint248",
+          "name": "",
+          "type": "uint248"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "adapterMeta",
+      "outputs": [
+        {
+          "internalType": "uint248",
+          "name": "id",
+          "type": "uint248"
+        },
+        {
+          "internalType": "bool",
+          "name": "enabled",
+          "type": "bool"
+        },
+        {
+          "internalType": "uint256",
+          "name": "guard",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint8",
+          "name": "uDecimals",
+          "type": "uint8"
+        },
+        {
+          "internalType": "uint248",
+          "name": "level",
+          "type": "uint248"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        }
+      ],
+      "name": "addAdapter",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "mscale",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address[]",
+          "name": "_usrs",
+          "type": "address[]"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "_lscales",
+          "type": "uint256[]"
+        }
+      ],
+      "name": "backfillScale",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "usr",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "uBalTransfer",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        }
+      ],
+      "name": "collect",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "collected",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "uBal",
+          "type": "uint256"
+        }
+      ],
+      "name": "combine",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "tBal",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "cup",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "guarded",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "sponsor",
+          "type": "address"
+        }
+      ],
+      "name": "initSeries",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "pt",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "yt",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "isTrusted",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "tBal",
+          "type": "uint256"
+        }
+      ],
+      "name": "issue",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "uBal",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "lscales",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        }
+      ],
+      "name": "mscale",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "paused",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "periphery",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "permissionless",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        }
+      ],
+      "name": "pt",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "uBal",
+          "type": "uint256"
+        }
+      ],
+      "name": "redeem",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "tBal",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "series",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "pt",
+          "type": "address"
+        },
+        {
+          "internalType": "uint48",
+          "name": "issuance",
+          "type": "uint48"
+        },
+        {
+          "internalType": "address",
+          "name": "yt",
+          "type": "address"
+        },
+        {
+          "internalType": "uint96",
+          "name": "tilt",
+          "type": "uint96"
+        },
+        {
+          "internalType": "address",
+          "name": "sponsor",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "reward",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "iscale",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "mscale",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maxscale",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "internalType": "bool",
+          "name": "isOn",
+          "type": "bool"
+        }
+      ],
+      "name": "setAdapter",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "cap",
+          "type": "uint256"
+        }
+      ],
+      "name": "setGuard",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bool",
+          "name": "_guarded",
+          "type": "bool"
+        }
+      ],
+      "name": "setGuarded",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        },
+        {
+          "internalType": "bool",
+          "name": "trusted",
+          "type": "bool"
+        }
+      ],
+      "name": "setIsTrusted",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bool",
+          "name": "_paused",
+          "type": "bool"
+        }
+      ],
+      "name": "setPaused",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_periphery",
+          "type": "address"
+        }
+      ],
+      "name": "setPeriphery",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bool",
+          "name": "_permissionless",
+          "type": "bool"
+        }
+      ],
+      "name": "setPermissionless",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        }
+      ],
+      "name": "settleSeries",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "tokenHandler",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        }
+      ],
+      "name": "yt",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ]
+  

--- a/pkg/deployments/tasks/20220720-wsteth-adapter/abi/Periphery.json
+++ b/pkg/deployments/tasks/20220720-wsteth-adapter/abi/Periphery.json
@@ -1,0 +1,1070 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_divider",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_poolManager",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_spaceFactory",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_balancerVault",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "ExistingValue",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FactoryNotSupported",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FlashBorrowFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FlashUntrustedBorrower",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FlashUntrustedLoanInitiator",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OnlyPermissionless",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SwapTooSmall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TargetMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TargetNotSupported",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnexpectedSwapAmount",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      }
+    ],
+    "name": "AdapterDeployed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      }
+    ],
+    "name": "AdapterOnboarded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      }
+    ],
+    "name": "AdapterVerified",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bool",
+        "name": "isOn",
+        "type": "bool"
+      }
+    ],
+    "name": "FactoryChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "maturity",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sponsor",
+        "type": "address"
+      }
+    ],
+    "name": "SeriesSponsored",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "poolId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "assetIn",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "assetOut",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes4",
+        "name": "sig",
+        "type": "bytes4"
+      }
+    ],
+    "name": "Swapped",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "trusted",
+        "type": "bool"
+      }
+    ],
+    "name": "UserTrustUpdated",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "MIN_YT_SWAP_IN",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "PRICE_ESTIMATE_ACCEPTABLE_ERROR",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maturity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tBal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "mode",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minBptOut",
+        "type": "uint256"
+      }
+    ],
+    "name": "addLiquidityFromTarget",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "tAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "issued",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lpShares",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maturity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "uBal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "mode",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minBptOut",
+        "type": "uint256"
+      }
+    ],
+    "name": "addLiquidityFromUnderlying",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "tAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "issued",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lpShares",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "balancerVault",
+    "outputs": [
+      {
+        "internalType": "contract BalancerVault",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "f",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "target",
+        "type": "address"
+      }
+    ],
+    "name": "deployAdapter",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "divider",
+    "outputs": [
+      {
+        "internalType": "contract Divider",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "factories",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "isTrusted",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "srcAdapter",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "dstAdapter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "srcMaturity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "dstMaturity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lpBal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "minAmountsOut",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAccepted",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "mode",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bool",
+        "name": "intoTarget",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minBptOut",
+        "type": "uint256"
+      }
+    ],
+    "name": "migrateLiquidity",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "tAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "issued",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lpShares",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "ptBal",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "initiator",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "onFlashLoan",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "addAdapter",
+        "type": "bool"
+      }
+    ],
+    "name": "onboardAdapter",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "poolManager",
+    "outputs": [
+      {
+        "internalType": "contract PoolManager",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maturity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lpBal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "minAmountsOut",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAccepted",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "intoTarget",
+        "type": "bool"
+      }
+    ],
+    "name": "removeLiquidity",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "tBal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "ptBal",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maturity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lpBal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "minAmountsOut",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAccepted",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "intoTarget",
+        "type": "bool"
+      }
+    ],
+    "name": "removeLiquidityAndUnwrapTarget",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "uBal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "ptBal",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "f",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "isOn",
+        "type": "bool"
+      }
+    ],
+    "name": "setFactory",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "trusted",
+        "type": "bool"
+      }
+    ],
+    "name": "setIsTrusted",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "spaceFactory",
+    "outputs": [
+      {
+        "internalType": "contract SpaceFactoryLike",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maturity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "withPool",
+        "type": "bool"
+      }
+    ],
+    "name": "sponsorSeries",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "pt",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "yt",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maturity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "ptBal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAccepted",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapPTsForTarget",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "tBal",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maturity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "ptBal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAccepted",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapPTsForUnderlying",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "uBal",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maturity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tBal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAccepted",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapTargetForPTs",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "ptBal",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maturity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tBal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAccepted",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapTargetForYTs",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "ytBal",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maturity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "uBal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAccepted",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapUnderlyingForPTs",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "ptBal",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maturity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "uBal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAccepted",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapUnderlyingForYTs",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "ytBal",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maturity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "ytBal",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapYTsForTarget",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "tBal",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maturity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "ytBal",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapYTsForUnderlying",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "uBal",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "verified",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "addToPool",
+        "type": "bool"
+      }
+    ],
+    "name": "verifyAdapter",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/pkg/deployments/tasks/20220720-wsteth-adapter/index.js
+++ b/pkg/deployments/tasks/20220720-wsteth-adapter/index.js
@@ -1,0 +1,86 @@
+const { task } = require("hardhat/config");
+const { mainnet } = require("./input");
+
+const { SENSE_MULTISIG } = require("../../hardhat.addresses");
+
+const dividerAbi = require("./abi/Divider.json");
+const peripheryAbi = require("./abi/Periphery.json");
+
+task(
+  "20220720-wsteth-adapter",
+  "Deploys wstETH adapter (with stETH as underlying)",
+).setAction(async ({}, { ethers }) => {
+  const { deploy } = deployments;
+  const { deployer } = await getNamedAccounts();
+  const chainId = await getChainId();
+  const deployerSigner = await ethers.getSigner(deployer);
+
+  let divider = new ethers.Contract(mainnet.divider, dividerAbi);
+  let periphery = new ethers.Contract(mainnet.periphery, peripheryAbi);
+
+  console.log(`Deploying from ${deployer} on chain ${chainId}`);
+  console.log("\n-------------------------------------------------------");
+
+  for (let adapter of mainnet.adapters) {
+    const { contractName, deploymentParams, target } = adapter;
+    const { underlying, ifee, adapterParams } = deploymentParams;
+    
+    divider = divider.connect(deployerSigner);
+    periphery = periphery.connect(deployerSigner);
+
+    console.log(`\nDeploy ${contractName}`);
+    const { address: adapterAddress } = await deploy(contractName, {
+      from: deployer,
+      args: [divider.address, target.address, underlying, ifee, [...Object.values(adapterParams)]],
+      log: true,
+    });
+    console.log(`${contractName} adapter deployed at ${adapterAddress}`);
+
+    if (chainId === "111") {
+      console.log("\n-------------------------------------------------------");
+      console.log("Checking multisig txs by impersonating the address");
+
+      if (!SENSE_MULTISIG.has(chainId)) throw Error("No multisig found");
+      const senseAdminMultisigAddress = SENSE_MULTISIG.get(chainId);
+      await hre.network.provider.request({
+        method: "hardhat_impersonateAccount",
+        params: [senseAdminMultisigAddress],
+      });
+      const multisigSigner = await hre.ethers.getSigner(senseAdminMultisigAddress);
+      divider = divider.connect(multisigSigner);
+      periphery = periphery.connect(multisigSigner);
+
+      console.log(`Set ${contractName} adapter issuance cap to ${target.guard}`);
+      await divider.setGuard(adapterAddress, target.guard).then(tx => tx.wait());
+
+      console.log(`Verify ${contractName} adapter`);
+      await periphery.verifyAdapter(adapterAddress, false).then(tx => tx.wait());
+
+      console.log(`Onboard ${contractName} adapter`);
+      await periphery.onboardAdapter(adapterAddress, true).then(tx => tx.wait());
+
+      await hre.network.provider.request({
+        method: "hardhat_stopImpersonatingAccount",
+        params: [senseAdminMultisigAddress],
+      });
+    }
+
+    console.log(`Can call scale value`);
+    const { abi: adapterAbi } = await deployments.getArtifact(contractName);
+    const adptr = new ethers.Contract(adapterAddress, adapterAbi, deployerSigner);
+    const scale = await adptr.callStatic.scale();
+    console.log(`-> scale: ${scale.toString()}`);
+
+    console.log("\n-------------------------------------------------------");
+    console.log("\nACTIONS TO BE DONE ON DEFENDER: ");
+    console.log("\n1. Set guard to 500 ETH on Divider");
+    console.log("\n2. Verify adapter on Periphery");
+    console.log("\n3. Onboard adapter on Periphery");
+
+    // verify adapter contract on etherscan
+    if (chainId !== "111") {
+      console.log("\n-------------------------------------------------------");
+      await verifyOnEtherscan(adapterAddress, [divider, target.address, await target.underlying(), ifee, adapterParams, reward]);
+    }
+  }
+});

--- a/pkg/deployments/tasks/20220720-wsteth-adapter/input.js
+++ b/pkg/deployments/tasks/20220720-wsteth-adapter/input.js
@@ -19,7 +19,7 @@ const MAINNET_ADAPTERS = [
       adapterParams: {
         oracle: MASTER_ORACLE.get("1"),
         stake: WETH_TOKEN.get("1"),
-        stakeSize: ethers.utils.parseEther("0"),
+        stakeSize: ethers.utils.parseEther("0.25"),
         minm: ((365.25 * 24 * 60 * 60) / 12).toString(), // 1 month
         maxm: (10 * 365.25 * 24 * 60 * 60).toString(), // 10 years
         tilt: 0, 

--- a/pkg/deployments/tasks/20220720-wsteth-adapter/input.js
+++ b/pkg/deployments/tasks/20220720-wsteth-adapter/input.js
@@ -1,0 +1,39 @@
+const { WETH_TOKEN, WSTETH_TOKEN, MASTER_ORACLE } = require("../../hardhat.addresses");
+const ethers = require("ethers");
+
+// List of adapters to deploy directly (without factory)
+const MAINNET_ADAPTERS = [
+  {
+    contractName: "WstETHAdapter",
+    target: {
+      name: "wstETH",
+      guard: ethers.utils.parseEther("100"),
+      series: [],
+      address: WSTETH_TOKEN.get("1"),
+    },
+    deploymentParams: {
+      divider: "0x86bA3E96Be68563E41c2f5769F1AF9fAf758e6E0",
+      target: WSTETH_TOKEN.get("1"), 
+      underlying: WETH_TOKEN.get("1"), 
+      ifee: ethers.utils.parseEther("0"),
+      adapterParams: {
+        oracle: MASTER_ORACLE.get("1"),
+        stake: WETH_TOKEN.get("1"),
+        stakeSize: ethers.utils.parseEther("0"),
+        minm: ((365.25 * 24 * 60 * 60) / 12).toString(), // 1 month
+        maxm: (10 * 365.25 * 24 * 60 * 60).toString(), // 10 years
+        tilt: 0, 
+        level: 31,
+        mode: 0, // 0 monthly
+      }
+    },
+  },
+];
+
+module.exports = {
+  mainnet: {
+    divider: "0x86bA3E96Be68563E41c2f5769F1AF9fAf758e6E0",
+    periphery: "0xFff11417a58781D3C72083CB45EF54d79Cd02437",
+    adapters: MAINNET_ADAPTERS,
+  },
+};

--- a/pkg/deployments/tasks/index.js
+++ b/pkg/deployments/tasks/index.js
@@ -5,3 +5,4 @@ require("./20220517-long-wsteth-adapter");
 require("./20220518-space-factory");
 require("./20220531-fuse-factory");
 require("./20220714-goerli-permissionless-adapter");
+require("./20220720-wsteth-adapter");

--- a/pkg/utils/src/libs/Errors.sol
+++ b/pkg/utils/src/libs/Errors.sol
@@ -19,6 +19,7 @@ library Errors {
     error SenderNotEligible();
     error TargetMismatch();
     error TargetNotSupported();
+    error InvalidPrice();
 
     // Divider
     error AlreadySettled();


### PR DESCRIPTION
## Motivation

We want to remove the stETH peg exposure out from our adapter.

## Solution

Remove ETH as the underlying of this adapter and use stETH instead.

## Implementer Checklist

<!--
Fill out the checklist below as applicable to your change. Bug fixes and new features must 
check off all of the required items.
-->


- [ ]  [FIRST TIME ONLY] Review the [Solcurity](https://github.com/Rari-Capital/solcurity) standard
- [ ]  [OPTIONAL] Create a reference implementation (in python or JS)
- [x]  Create a short "Motivation" section for the PR
- [x]  Write a spec for the feature and put it in the PR description – basic function names and expected state transitions is OK
- [x]  Check all of the new revert paths with concrete tests
- [ ]  Check all of the new storage slot writes with concrete tests – do not make the passing test case the trivial case!
- [x]  Go line-by-line through the new code and ensure it has all been covered by concrete tests – since we don’t have a coverage engine for foundry yet, you can imagine how one might check that each different code path is covered
- [x]  Simplify the implementation and spend some time trying to minimize gas costs
- [ ]  Write fuzz tests for the feature – try everything to break the implementation (is this function monotonically in/decreasing, should it always be less than something else, etc)
- [ ]  Capture bugs discovered during the above steps in concrete tests (regression tests)
- [x]  Add integration tests – fuzz or concrete tests that test how the new code affects the entire system, either locally or with a mainnet fork
- [ ]  [OPTIONAL] Integrate the feature into the deployment scripts
- [ ]  [OPTIONAL] Add new sanity checks to the deployment scripts
- [ ]  Get the PR reviewed by at least two people