### PR TITLE
GEN-1149: add deployment scripts for 4626 factory

### DIFF
--- a/pkg/deployments/hardhat.addresses.js
+++ b/pkg/deployments/hardhat.addresses.js
@@ -1,7 +1,9 @@
-// 1 -> Mainnet
-// 5 -> Goerli
-// 111 -> Local Mainnet fork
-// 42161 -> Arbitrum
+const CHAINS = {
+    MAINNET: 1,
+    GOERLI: 5,
+    HARDHAT: 111,
+    ARBITRUM: 42161,
+}
 
 // For dev scenarios ------------
 
@@ -172,4 +174,5 @@ exports.CRV_TOKEN = CRV_TOKEN;
 exports.TRIBE_CONVEX = TRIBE_CONVEX;
 exports.REWARDS_DISTRIBUTOR_CVX = REWARDS_DISTRIBUTOR_CVX;
 exports.REWARDS_DISTRIBUTOR_CRV = REWARDS_DISTRIBUTOR_CRV;
+exports.CHAINS = CHAINS;
 // ------------------------------------

--- a/pkg/deployments/src/index.sol
+++ b/pkg/deployments/src/index.sol
@@ -8,6 +8,8 @@ import "@sense-finance/v1-core/src/adapters/implementations/compound/CFactory.so
 import "@sense-finance/v1-core/src/adapters/implementations/fuse/FFactory.sol";
 import "@sense-finance/v1-core/src/adapters/implementations/lido/WstETHAdapter.sol";
 import "@sense-finance/v1-core/src/adapters/abstract/factories/ERC4626Factory.sol";
+import "@sense-finance/v1-core/src/adapters/implementations/oracles/ChainlinkPriceOracle.sol";
+import "@sense-finance/v1-core/src/adapters/implementations/oracles/MasterPriceOracle.sol";
 import "@sense-finance/v1-core/src/tests/test-helpers/mocks/fuse/MockOracle.sol";
 import "@sense-finance/v1-core/src/tests/test-helpers/mocks/fuse/MockComptroller.sol";
 import "@sense-finance/v1-core/src/tests/test-helpers/mocks/fuse/MockFuseDirectory.sol";

--- a/pkg/deployments/tasks/20220721-4626-factory/abi/Divider.json
+++ b/pkg/deployments/tasks/20220721-4626-factory/abi/Divider.json
@@ -1,0 +1,1181 @@
+[
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_cup",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_tokenHandler",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [],
+      "name": "AlreadySettled",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "CollectNotSettled",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "CombineRestricted",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "DuplicateSeries",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ExistingValue",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "GuardCapReached",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidAdapter",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidMaturity",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "IssuanceFeeCapExceeded",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "IssuanceRestricted",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "IssueOnSettle",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "NotSettled",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OnlyPeriphery",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OnlyPermissionless",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OnlyYT",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OutOfWindowBoundaries",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "RedeemRestricted",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "SeriesDoesNotExist",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "id",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "bool",
+          "name": "isOn",
+          "type": "bool"
+        }
+      ],
+      "name": "AdapterChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "mscale",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address[]",
+          "name": "_usrs",
+          "type": "address[]"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256[]",
+          "name": "_lscales",
+          "type": "uint256[]"
+        }
+      ],
+      "name": "Backfilled",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "collected",
+          "type": "uint256"
+        }
+      ],
+      "name": "Collected",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "balance",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "Combined",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "cap",
+          "type": "uint256"
+        }
+      ],
+      "name": "GuardChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bool",
+          "name": "guarded",
+          "type": "bool"
+        }
+      ],
+      "name": "GuardedChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "balance",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "Issued",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "Paused",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "periphery",
+          "type": "address"
+        }
+      ],
+      "name": "PeripheryChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bool",
+          "name": "permissionless",
+          "type": "bool"
+        }
+      ],
+      "name": "PermissionlessChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "redeemed",
+          "type": "uint256"
+        }
+      ],
+      "name": "PrincipalRedeemed",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "pt",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "yt",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sponsor",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "target",
+          "type": "address"
+        }
+      ],
+      "name": "SeriesInitialized",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "settler",
+          "type": "address"
+        }
+      ],
+      "name": "SeriesSettled",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "Unpaused",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "trusted",
+          "type": "bool"
+        }
+      ],
+      "name": "UserTrustUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "redeemed",
+          "type": "uint256"
+        }
+      ],
+      "name": "YTRedeemed",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "ISSUANCE_FEE_CAP",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SETTLEMENT_WINDOW",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SPONSOR_WINDOW",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "adapterAddresses",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "adapterCounter",
+      "outputs": [
+        {
+          "internalType": "uint248",
+          "name": "",
+          "type": "uint248"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "adapterMeta",
+      "outputs": [
+        {
+          "internalType": "uint248",
+          "name": "id",
+          "type": "uint248"
+        },
+        {
+          "internalType": "bool",
+          "name": "enabled",
+          "type": "bool"
+        },
+        {
+          "internalType": "uint256",
+          "name": "guard",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint8",
+          "name": "uDecimals",
+          "type": "uint8"
+        },
+        {
+          "internalType": "uint248",
+          "name": "level",
+          "type": "uint248"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        }
+      ],
+      "name": "addAdapter",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "mscale",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address[]",
+          "name": "_usrs",
+          "type": "address[]"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "_lscales",
+          "type": "uint256[]"
+        }
+      ],
+      "name": "backfillScale",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "usr",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "uBalTransfer",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        }
+      ],
+      "name": "collect",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "collected",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "uBal",
+          "type": "uint256"
+        }
+      ],
+      "name": "combine",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "tBal",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "cup",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "guarded",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "sponsor",
+          "type": "address"
+        }
+      ],
+      "name": "initSeries",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "pt",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "yt",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "isTrusted",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "tBal",
+          "type": "uint256"
+        }
+      ],
+      "name": "issue",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "uBal",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "lscales",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        }
+      ],
+      "name": "mscale",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "paused",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "periphery",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "permissionless",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        }
+      ],
+      "name": "pt",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "uBal",
+          "type": "uint256"
+        }
+      ],
+      "name": "redeem",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "tBal",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "series",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "pt",
+          "type": "address"
+        },
+        {
+          "internalType": "uint48",
+          "name": "issuance",
+          "type": "uint48"
+        },
+        {
+          "internalType": "address",
+          "name": "yt",
+          "type": "address"
+        },
+        {
+          "internalType": "uint96",
+          "name": "tilt",
+          "type": "uint96"
+        },
+        {
+          "internalType": "address",
+          "name": "sponsor",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "reward",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "iscale",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "mscale",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maxscale",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "internalType": "bool",
+          "name": "isOn",
+          "type": "bool"
+        }
+      ],
+      "name": "setAdapter",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "cap",
+          "type": "uint256"
+        }
+      ],
+      "name": "setGuard",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bool",
+          "name": "_guarded",
+          "type": "bool"
+        }
+      ],
+      "name": "setGuarded",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        },
+        {
+          "internalType": "bool",
+          "name": "trusted",
+          "type": "bool"
+        }
+      ],
+      "name": "setIsTrusted",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bool",
+          "name": "_paused",
+          "type": "bool"
+        }
+      ],
+      "name": "setPaused",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_periphery",
+          "type": "address"
+        }
+      ],
+      "name": "setPeriphery",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bool",
+          "name": "_permissionless",
+          "type": "bool"
+        }
+      ],
+      "name": "setPermissionless",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        }
+      ],
+      "name": "settleSeries",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "tokenHandler",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "adapter",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maturity",
+          "type": "uint256"
+        }
+      ],
+      "name": "yt",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ]
+  

--- a/pkg/deployments/tasks/20220721-4626-factory/abi/Periphery.json
+++ b/pkg/deployments/tasks/20220721-4626-factory/abi/Periphery.json
@@ -1,0 +1,1075 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_divider",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_poolManager",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_spaceFactory",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_balancerVault",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "ExistingValue",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FactoryNotSupported",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FlashBorrowFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FlashUntrustedBorrower",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FlashUntrustedLoanInitiator",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OnlyPermissionless",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SwapTooSmall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TargetMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TargetNotSupported",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnexpectedSwapAmount",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      }
+    ],
+    "name": "AdapterDeployed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      }
+    ],
+    "name": "AdapterOnboarded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      }
+    ],
+    "name": "AdapterVerified",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bool",
+        "name": "isOn",
+        "type": "bool"
+      }
+    ],
+    "name": "FactoryChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "maturity",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sponsor",
+        "type": "address"
+      }
+    ],
+    "name": "SeriesSponsored",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "poolId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "assetIn",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "assetOut",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes4",
+        "name": "sig",
+        "type": "bytes4"
+      }
+    ],
+    "name": "Swapped",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "trusted",
+        "type": "bool"
+      }
+    ],
+    "name": "UserTrustUpdated",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "MIN_YT_SWAP_IN",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "PRICE_ESTIMATE_ACCEPTABLE_ERROR",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maturity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tBal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "mode",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minBptOut",
+        "type": "uint256"
+      }
+    ],
+    "name": "addLiquidityFromTarget",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "tAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "issued",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lpShares",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maturity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "uBal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "mode",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minBptOut",
+        "type": "uint256"
+      }
+    ],
+    "name": "addLiquidityFromUnderlying",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "tAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "issued",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lpShares",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "balancerVault",
+    "outputs": [
+      {
+        "internalType": "contract BalancerVault",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "f",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "target",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "deployAdapter",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "divider",
+    "outputs": [
+      {
+        "internalType": "contract Divider",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "factories",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "isTrusted",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "srcAdapter",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "dstAdapter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "srcMaturity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "dstMaturity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lpBal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "minAmountsOut",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAccepted",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "mode",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bool",
+        "name": "intoTarget",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minBptOut",
+        "type": "uint256"
+      }
+    ],
+    "name": "migrateLiquidity",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "tAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "issued",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lpShares",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "ptBal",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "initiator",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "onFlashLoan",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "addAdapter",
+        "type": "bool"
+      }
+    ],
+    "name": "onboardAdapter",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "poolManager",
+    "outputs": [
+      {
+        "internalType": "contract PoolManager",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maturity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lpBal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "minAmountsOut",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAccepted",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "intoTarget",
+        "type": "bool"
+      }
+    ],
+    "name": "removeLiquidity",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "tBal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "ptBal",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maturity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lpBal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "minAmountsOut",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAccepted",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "intoTarget",
+        "type": "bool"
+      }
+    ],
+    "name": "removeLiquidityAndUnwrapTarget",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "uBal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "ptBal",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "f",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "isOn",
+        "type": "bool"
+      }
+    ],
+    "name": "setFactory",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "trusted",
+        "type": "bool"
+      }
+    ],
+    "name": "setIsTrusted",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "spaceFactory",
+    "outputs": [
+      {
+        "internalType": "contract SpaceFactoryLike",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maturity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "withPool",
+        "type": "bool"
+      }
+    ],
+    "name": "sponsorSeries",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "pt",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "yt",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maturity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "ptBal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAccepted",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapPTsForTarget",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "tBal",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maturity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "ptBal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAccepted",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapPTsForUnderlying",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "uBal",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maturity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tBal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAccepted",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapTargetForPTs",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "ptBal",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maturity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tBal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAccepted",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapTargetForYTs",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "ytBal",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maturity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "uBal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAccepted",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapUnderlyingForPTs",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "ptBal",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maturity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "uBal",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAccepted",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapUnderlyingForYTs",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "ytBal",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maturity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "ytBal",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapYTsForTarget",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "tBal",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maturity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "ytBal",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapYTsForUnderlying",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "uBal",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "verified",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "addToPool",
+        "type": "bool"
+      }
+    ],
+    "name": "verifyAdapter",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/pkg/deployments/tasks/20220721-4626-factory/index.js
+++ b/pkg/deployments/tasks/20220721-4626-factory/index.js
@@ -30,6 +30,12 @@ task(
     log: true,
   });
 
+  // if mainnet or goerli, verify on etherscan
+  if ([CHAINS.MAINNET, CHAINS.GOERLI].includes(chainId)) {
+    console.log("\n-------------------------------------------------------");
+    await verifyOnEtherscan(chainlinkOracleAddress, [maxSecondsBeforePriceIsStale]);
+  }
+
   console.log("\n-------------------------------------------------------");
   console.log("\nDeploy Sense Master Price Oracle");
   const { address: masterOracleAddress } = await deploy("MasterPriceOracle", {
@@ -37,6 +43,12 @@ task(
     args: [chainlinkOracleAddress, [], []],
     log: true,
   });
+
+  // if mainnet or goerli, verify on etherscan
+  if ([CHAINS.MAINNET, CHAINS.GOERLI].includes(chainId)) {
+    console.log("\n-------------------------------------------------------");
+    await verifyOnEtherscan(masterOracleAddress, [chainlinkOracleAddress, [], []]);
+  }
 
   console.log("\n-------------------------------------------------------");
   console.log("\nDeploy Factories");
@@ -76,9 +88,6 @@ task(
     // if mainnet or goerli, verify on etherscan
     if ([CHAINS.MAINNET, CHAINS.GOERLI].includes(chainId)) {
       console.log("\n-------------------------------------------------------");
-      console.log("Waiting 20 seconds for Etherscan to sync...");
-      await delay(20);
-      console.log("Trying to verify contract on Etherscan...");
       await verifyOnEtherscan(factoryAddress, [divider.address, factoryParams]);
     }
 

--- a/pkg/deployments/tasks/20220721-4626-factory/index.js
+++ b/pkg/deployments/tasks/20220721-4626-factory/index.js
@@ -1,0 +1,117 @@
+const { task } = require("hardhat/config");
+const data = require("./input");
+
+const { SENSE_MULTISIG } = require("../../hardhat.addresses");
+
+const dividerAbi = require("./abi/Divider.json");
+const peripheryAbi = require("./abi/Periphery.json");
+const { delay, verifyOnEtherscan } = require("../../hardhat.utils");
+
+task(
+  "20220721-4626-factory",
+  "Deploys 4626 Factory and adds it to the Periphery. Also deploys Sense Master & Chainlink Oracles",
+).setAction(async ({}, { ethers }) => {
+  const { deploy } = deployments;
+  const { deployer } = await getNamedAccounts();
+  const chainId = await getChainId();
+  const deployerSigner = await ethers.getSigner(deployer);
+
+  console.log(`Deploying from ${deployer} on chain ${chainId}`);
+
+  const { divider: dividerAddress, periphery: peripheryAddress, factories, maxSecondsBeforePriceIsStale } = data[hre.network.name] || data.mainnet;
+  let divider = new ethers.Contract(dividerAddress, dividerAbi, deployerSigner);
+  let periphery = new ethers.Contract(peripheryAddress, peripheryAbi, deployerSigner);
+
+  console.log("\n-------------------------------------------------------");
+  console.log("\nDeploy Sense Chainlink Price Oracle");
+  const { address: chainlinkOracleAddress } = await deploy("ChainlinkPriceOracle", {
+    from: deployer,
+    args: [maxSecondsBeforePriceIsStale],
+    log: true,
+  });
+
+  console.log("\n-------------------------------------------------------");
+  console.log("\nDeploy Sense Master Price Oracle");
+  const { address: masterOracleAddress } = await deploy("MasterPriceOracle", {
+    from: deployer,
+    args: [chainlinkOracleAddress, [], []],
+    log: true,
+  });
+
+  console.log("\n-------------------------------------------------------");
+  console.log("\nDeploy Factories");
+  for (let factory of factories) {
+    const {
+      contractName: factoryContractName,
+      ifee,
+      stake,
+      stakeSize,
+      minm,
+      maxm,
+      mode,
+      tilt,
+    } = factory;
+
+    oracle = masterOracleAddress;
+    console.log(
+      `\nDeploy ${factoryContractName} with params ${JSON.stringify({
+        ifee: ifee.toString(),
+        stake,
+        stakeSize: stakeSize.toString(),
+        minm,
+        maxm,
+        mode,
+        oracle,
+        tilt
+      })}}`,
+    );
+    const factoryParams = [oracle, stake, stakeSize, minm, maxm, ifee, mode, tilt];
+    const { address: factoryAddress } = await deploy(factoryContractName, {
+      from: deployer,
+      args: [divider.address, factoryParams],
+      log: true,
+    });
+
+    console.log(`${factoryContractName} deployed to ${factoryAddress}`);
+
+    // if mainnet or goerli, verify on etherscan
+    if (["1", "5"].includes(chainId)) {
+      console.log("\n-------------------------------------------------------");
+      console.log("Waiting 20 seconds for Etherscan to sync...");
+      await delay(20);
+      console.log("Trying to verify contract on Etherscan...");
+      await verifyOnEtherscan(factoryAddress, [divider.address, factoryParams]);
+    }
+
+    if (chainId === "111") {
+      console.log("\n-------------------------------------------------------");
+      console.log("Checking multisig txs by impersonating the address");
+
+      if (!SENSE_MULTISIG.has(chainId)) throw Error("No balancer vault found");
+      const senseAdminMultisigAddress = SENSE_MULTISIG.get(chainId);
+      await hre.network.provider.request({
+        method: "hardhat_impersonateAccount",
+        params: [senseAdminMultisigAddress],
+      });
+
+      const multisigSigner = await hre.ethers.getSigner(senseAdminMultisigAddress);
+      divider = divider.connect(multisigSigner);
+      periphery = periphery.connect(multisigSigner);
+
+      console.log(`\nAdd ${factoryContractName} support to Periphery`);
+      await (await periphery.setFactory(factoryAddress, true)).wait();
+      await hre.network.provider.request({
+        method: "hardhat_stopImpersonatingAccount",
+        params: [senseAdminMultisigAddress],
+      });
+    }
+
+    if (["1", "5"].includes(chainId)) {
+      console.log("\n-------------------------------------------------------");
+      console.log("\nACTIONS TO BE DONE ON DEFENDER: ");
+      console.log("\n1. Set factory on Periphery");
+    }
+
+  }
+
+});

--- a/pkg/deployments/tasks/20220721-4626-factory/input.js
+++ b/pkg/deployments/tasks/20220721-4626-factory/input.js
@@ -1,0 +1,30 @@
+const { WETH_TOKEN } = require("../../hardhat.addresses");
+const ethers = require("ethers");
+
+const MAINNET_FACTORIES = [
+  {
+    contractName: "ERC4626Factory",
+    ifee: ethers.utils.parseEther("0.0025"),
+    stake: WETH_TOKEN.get("1"),
+    stakeSize: ethers.utils.parseEther("0.25"),
+    minm: ((365.25 * 24 * 60 * 60) / 12).toString(), // 1 month
+    maxm: (10 * 365.25 * 24 * 60 * 60).toString(), // 10 years
+    mode: 0, // 0 = monthly
+    tilt: 0
+  },
+];
+
+module.exports = {
+  mainnet: {
+    divider: "0x86bA3E96Be68563E41c2f5769F1AF9fAf758e6E0",
+    periphery: "0xFff11417a58781D3C72083CB45EF54d79Cd02437", 
+    factories: MAINNET_FACTORIES,
+    maxSecondsBeforePriceIsStale: (3 * 24 * 60 * 60).toString() // 3 days
+  },
+  goerli: {
+    divider: "0xa1514E3bA51C59d4E76956409143aE9734883Fd5",
+    periphery: "0x03E98F3e15260C315eD60205a2708F9f37214776", 
+    factories: MAINNET_FACTORIES,
+    maxSecondsBeforePriceIsStale: (3 * 24 * 60 * 60).toString() // 3 days
+  },
+};

--- a/pkg/deployments/tasks/20220721-4626-factory/input.js
+++ b/pkg/deployments/tasks/20220721-4626-factory/input.js
@@ -15,13 +15,15 @@ const MAINNET_FACTORIES = [
 ];
 
 module.exports = {
-  mainnet: {
+  // mainnet
+  1: {
     divider: "0x86bA3E96Be68563E41c2f5769F1AF9fAf758e6E0",
     periphery: "0xFff11417a58781D3C72083CB45EF54d79Cd02437", 
     factories: MAINNET_FACTORIES,
     maxSecondsBeforePriceIsStale: (3 * 24 * 60 * 60).toString() // 3 days
   },
-  goerli: {
+  // goerli
+  5: {
     divider: "0xa1514E3bA51C59d4E76956409143aE9734883Fd5",
     periphery: "0x03E98F3e15260C315eD60205a2708F9f37214776", 
     factories: MAINNET_FACTORIES,

--- a/pkg/deployments/tasks/index.js
+++ b/pkg/deployments/tasks/index.js
@@ -7,3 +7,4 @@ require("./20220531-fuse-factory");
 require("./20220714-goerli-permissionless-adapter");
 require("./20220720-wsteth-adapter");
 require("./20220727-cfactory");
+require("./20220721-4626-factory");


### PR DESCRIPTION
## Motivation

Have 4626 factory support live

## Solution

Create hardhat task to deploy `ERC4626Factory.sol` and oracles: `MasterPriceOracle.sol` and `ChainlinkPriceOracle.sol`.
We are **not** yet adding support for the `ERC4626CropsFactory.sol`.

## Implementer Checklist

<!--
Fill out the checklist below as applicable to your change. Bug fixes and new features must 
check off all of the required items.
-->


- [ ]  [FIRST TIME ONLY] Review the [Solcurity](https://github.com/Rari-Capital/solcurity) standard
- [ ]  [OPTIONAL] Create a reference implementation (in python or JS)
- [x]  Create a short "Motivation" section for the PR
- [x]  Write a spec for the feature and put it in the PR description – basic function names and expected state transitions is OK
- [ ]  Check all of the new revert paths with concrete tests
- [ ]  Check all of the new storage slot writes with concrete tests – do not make the passing test case the trivial case!
- [ ]  Go line-by-line through the new code and ensure it has all been covered by concrete tests – since we don’t have a coverage engine for foundry yet, you can imagine how one might check that each different code path is covered
- [ ]  Simplify the implementation and spend some time trying to minimize gas costs
- [ ]  Write fuzz tests for the feature – try everything to break the implementation (is this function monotonically in/decreasing, should it always be less than something else, etc)
- [ ]  Capture bugs discovered during the above steps in concrete tests (regression tests)
- [ ]  Add integration tests – fuzz or concrete tests that test how the new code affects the entire system, either locally or with a mainnet fork
- [ ]  [OPTIONAL] Integrate the feature into the deployment scripts
- [ ]  [OPTIONAL] Add new sanity checks to the deployment scripts
- [ ]  Get the PR reviewed by at least two people