### PR TITLE
feat(Factories): set guard on deployAdapter()

### DIFF
--- a/pkg/core/src/adapters/abstract/factories/BaseFactory.sol
+++ b/pkg/core/src/adapters/abstract/factories/BaseFactory.sol
@@ -78,16 +78,13 @@ abstract contract BaseFactory {
 
         // Get Underlying-ETH price
         try BaseAdapter(adapter).getUnderlyingPrice() returns (uint256 underlyingPriceInEth) {
-            // Get ETH-USD price from Chainlink
+            // Get ETH-USD price from Chainlink (in 8 decimals base)
             (, int256 ethPrice, , uint256 ethUpdatedAt, ) = ChainlinkOracleLike(ETH_USD_PRICEFEED).latestRoundData();
 
-            if (block.timestamp - ethUpdatedAt > 1 hours) revert Errors.InvalidPrice();
+            if (block.timestamp - ethUpdatedAt > 1.5 hours) revert Errors.InvalidPrice();
 
             // Calculate Underlying-USD price (normalised to 18 deicmals)
-            ChainlinkOracleLike(ETH_USD_PRICEFEED).decimals();
-            uint256 price = underlyingPriceInEth.fmul(
-                uint256(ethPrice) * 10**(18 - ChainlinkOracleLike(ETH_USD_PRICEFEED).decimals())
-            );
+            uint256 price = underlyingPriceInEth.fmul(uint256(ethPrice) * 1e10);
 
             // Calculate Target-USD price
             price = BaseAdapter(adapter).scale().fdiv(price);

--- a/pkg/core/src/adapters/abstract/factories/BaseFactory.sol
+++ b/pkg/core/src/adapters/abstract/factories/BaseFactory.sol
@@ -75,8 +75,6 @@ abstract contract BaseFactory {
     function _setGuard(address adapter) internal {
         // We only want to execute this if divider is guarded
         if (Divider(divider).guarded()) {
-            uint256 guard = factoryParams.guard;
-
             // Get Underlying-ETH price
             try BaseAdapter(adapter).getUnderlyingPrice() returns (uint256 underlyingPriceInEth) {
                 // Get ETH-USD price from Chainlink (in 8 decimals base)
@@ -90,10 +88,9 @@ abstract contract BaseFactory {
 
                 // Calculate Target-USD price
                 price = BaseAdapter(adapter).scale().fdiv(price);
-                guard = guard.fdiv(price);
-            } catch {}
 
-            Divider(divider).setGuard(adapter, guard);
+                Divider(divider).setGuard(adapter, factoryParams.guard.fdiv(price));
+            } catch {}
         }
     }
 

--- a/pkg/core/src/adapters/abstract/factories/BaseFactory.sol
+++ b/pkg/core/src/adapters/abstract/factories/BaseFactory.sol
@@ -81,7 +81,7 @@ abstract contract BaseFactory {
             // Get ETH-USD price from Chainlink (in 8 decimals base)
             (, int256 ethPrice, , uint256 ethUpdatedAt, ) = ChainlinkOracleLike(ETH_USD_PRICEFEED).latestRoundData();
 
-            if (block.timestamp - ethUpdatedAt > 1.5 hours) revert Errors.InvalidPrice();
+            if (block.timestamp - ethUpdatedAt > 2 hours) revert Errors.InvalidPrice();
 
             // Calculate Underlying-USD price (normalised to 18 deicmals)
             uint256 price = underlyingPriceInEth.fmul(uint256(ethPrice) * 1e10);

--- a/pkg/core/src/adapters/abstract/factories/BaseFactory.sol
+++ b/pkg/core/src/adapters/abstract/factories/BaseFactory.sol
@@ -5,9 +5,30 @@ pragma solidity 0.8.11;
 import { Errors } from "@sense-finance/v1-utils/src/libs/Errors.sol";
 import { BaseAdapter } from "../BaseAdapter.sol";
 import { Divider } from "../../../Divider.sol";
+import { FixedMath } from "../../../external/FixedMath.sol";
+import { Divider } from "../../../Divider.sol";
+
+interface ChainlinkOracleLike {
+    function latestRoundData()
+        external
+        view
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        );
+
+    function decimals() external view returns (uint256 decimals);
+}
 
 abstract contract BaseFactory {
+    using FixedMath for uint256;
+
     /* ========== CONSTANTS ========== */
+
+    address public constant ETH_USD_PRICEFEED = 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419; // Chainlink ETH-USD price feed
 
     /// @notice Sets level to `31` by default, which keeps all Divider lifecycle methods public
     /// (`issue`, `combine`, `collect`, etc), but not the `onRedeem` hook.
@@ -48,6 +69,31 @@ abstract contract BaseFactory {
     /// @param _target Address of the Target token
     /// @param _data Additional data needed to deploy the adapter
     function deployAdapter(address _target, bytes memory _data) external virtual returns (address adapter) {}
+
+    /// Set adapter's guard to $100`000 in target
+    /// @notice if Underlying-ETH price feed returns 0, we set the guard to 100000 target.
+    function _setGuard(address adapter) internal {
+        uint256 guard = uint256(100000 * 1e18);
+
+        // Get Underlying-ETH price
+        uint256 underlyingEthPrice = BaseAdapter(adapter).getUnderlyingPrice();
+
+        if (underlyingEthPrice > 0) {
+            // Get ETH-USD price from Chainlink
+            (, int256 ethPrice, , uint256 ethUpdatedAt, ) = ChainlinkOracleLike(ETH_USD_PRICEFEED).latestRoundData();
+            if (block.timestamp - ethUpdatedAt > 1 hours) revert Errors.InvalidPrice();
+
+            // Calculate Underlying-USD price (normalised to 18 deicmals)
+            uint256 price = underlyingEthPrice.fmul(uint256(ethPrice)) *
+                10**(18 - ChainlinkOracleLike(ETH_USD_PRICEFEED).decimals());
+
+            // Calculate Target-USD price
+            price = (BaseAdapter(adapter).scale()).fdiv(price);
+            guard = guard.fdiv(price);
+        }
+
+        Divider(divider).setGuard(adapter, guard);
+    }
 
     /* ========== LOGS ========== */
 

--- a/pkg/core/src/adapters/implementations/compound/CFactory.sol
+++ b/pkg/core/src/adapters/implementations/compound/CFactory.sol
@@ -5,10 +5,10 @@ pragma solidity 0.8.11;
 import { CropFactory } from "../../abstract/factories/CropFactory.sol";
 import { CAdapter, ComptrollerLike } from "./CAdapter.sol";
 import { BaseAdapter } from "../../abstract/BaseAdapter.sol";
-import { Errors } from "@sense-finance/v1-utils/src/libs/Errors.sol";
 
 // External references
 import { Bytes32AddressLib } from "@rari-capital/solmate/src/utils/Bytes32AddressLib.sol";
+import { Errors } from "@sense-finance/v1-utils/src/libs/Errors.sol";
 
 interface CTokenLike {
     function underlying() external view returns (address);
@@ -55,5 +55,7 @@ contract CFactory is CropFactory {
                 reward
             )
         );
+
+        _setGuard(adapter);
     }
 }

--- a/pkg/core/src/adapters/implementations/fuse/FFactory.sol
+++ b/pkg/core/src/adapters/implementations/fuse/FFactory.sol
@@ -5,10 +5,10 @@ pragma solidity 0.8.11;
 import { CropsFactory } from "../../abstract/factories/CropsFactory.sol";
 import { FAdapter, FComptrollerLike, RewardsDistributorLike } from "./FAdapter.sol";
 import { BaseAdapter } from "../../abstract/BaseAdapter.sol";
-import { Errors } from "@sense-finance/v1-utils/src/libs/Errors.sol";
 
 // External references
 import { Bytes32AddressLib } from "@rari-capital/solmate/src/utils/Bytes32AddressLib.sol";
+import { Errors } from "@sense-finance/v1-utils/src/libs/Errors.sol";
 
 interface FTokenLike {
     function underlying() external view returns (address);
@@ -77,6 +77,8 @@ contract FFactory is CropsFactory {
                 targetRewardsDistributors
             )
         );
+
+        _setGuard(adapter);
     }
 
     /// @notice Replace existing rewards tokens and distributorsfor a given adapter

--- a/pkg/core/src/adapters/implementations/lido/WstETHAdapter.sol
+++ b/pkg/core/src/adapters/implementations/lido/WstETHAdapter.sol
@@ -75,8 +75,8 @@ contract WstETHAdapter is BaseAdapter {
     function getUnderlyingPrice() external view override returns (uint256 price) {
         (, int256 stethPrice, , uint256 stethUpdatedAt, ) = PriceOracleLike(STETH_USD_PRICEFEED).latestRoundData();
         (, int256 ethPrice, , uint256 ethUpdatedAt, ) = PriceOracleLike(ETH_USD_PRICEFEED).latestRoundData();
-        if (block.timestamp - stethUpdatedAt > 1 hours) revert Errors.InvalidPrice();
-        if (block.timestamp - ethUpdatedAt > 1 hours) revert Errors.InvalidPrice();
+        if (block.timestamp - stethUpdatedAt > 2 hours) revert Errors.InvalidPrice();
+        if (block.timestamp - ethUpdatedAt > 2 hours) revert Errors.InvalidPrice();
         price = uint256(stethPrice).fdiv(uint256(ethPrice));
         if (price < 0) revert Errors.InvalidPrice();
     }

--- a/pkg/core/src/tests/Periphery.t.sol
+++ b/pkg/core/src/tests/Periphery.t.sol
@@ -140,7 +140,8 @@ contract PeripheryTest is TestHelper {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
-            tilt: 0
+            tilt: 0,
+            guard: DEFAULT_GUARD
         });
 
         address cropFactory;

--- a/pkg/core/src/tests/factories/BaseFactory.t.sol
+++ b/pkg/core/src/tests/factories/BaseFactory.t.sol
@@ -151,7 +151,7 @@ contract Factories is TestHelper {
         hevm.clearMockedCalls();
 
         // Since the call to Chainlink reverted when deploying the adapter via factory
-        // guard should be set to the guard of in the factory params
+        // guard should be set to 0
         (, , , , , , , , uint256 factoryGuard) = someFactory.factoryParams();
         (, , uint256 guard, ) = divider.adapterMeta(adapter);
         assertEq(guard, factoryGuard);

--- a/pkg/core/src/tests/factories/CFactory.tm.sol
+++ b/pkg/core/src/tests/factories/CFactory.tm.sol
@@ -27,6 +27,7 @@ contract CAdapterTestHelper is DSTest {
     uint256 public constant STAKE_SIZE = 1e18;
     uint256 public constant MIN_MATURITY = 2 weeks;
     uint256 public constant MAX_MATURITY = 14 weeks;
+    uint256 public constant DEFAULT_GUARD = 100000 * 1e18;
 
     function setUp() public {
         tokenHandler = new TokenHandler();
@@ -45,7 +46,8 @@ contract CAdapterTestHelper is DSTest {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
-            tilt: 0
+            tilt: 0,
+            guard: DEFAULT_GUARD
         });
         factory = new CFactory(address(divider), factoryParams, AddressBook.COMP);
         divider.setIsTrusted(address(factory), true); // add factory as a ward
@@ -67,7 +69,8 @@ contract CFactories is CAdapterTestHelper {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
-            tilt: 0
+            tilt: 0,
+            guard: DEFAULT_GUARD
         });
         CFactory otherCFactory = new CFactory(address(divider), factoryParams, AddressBook.COMP);
 
@@ -80,7 +83,8 @@ contract CFactories is CAdapterTestHelper {
             uint256 maxm,
             uint256 ifee,
             uint16 mode,
-            uint64 tilt
+            uint64 tilt,
+            uint256 guard
         ) = CFactory(otherCFactory).factoryParams();
 
         assertEq(CFactory(otherCFactory).divider(), address(divider));
@@ -92,6 +96,7 @@ contract CFactories is CAdapterTestHelper {
         assertEq(mode, MODE);
         assertEq(oracle, AddressBook.RARI_ORACLE);
         assertEq(tilt, 0);
+        assertEq(guard, DEFAULT_GUARD);
     }
 
     function testMainnetDeployAdapter() public {

--- a/pkg/core/src/tests/factories/CFactory.tm.sol
+++ b/pkg/core/src/tests/factories/CFactory.tm.sol
@@ -114,9 +114,9 @@ contract CFactories is CAdapterTestHelper {
 
         // As we are testing with a stablecoin here (DAI), we ca think the scale
         // as the cDAI - USD rate, so we want to assert that the guard (which should be $100'000)
-        // in target terms is approx 100'000 / scale (within 5%).
+        // in target terms is approx 100'000 / scale (within 10%).
         (, , uint256 guard, ) = divider.adapterMeta(address(adapter));
-        assertClose(guard, (100000 * 1e36) / scale, guard.fmul(0.005e18));
+        assertClose(guard, (100000 * 1e36) / scale, guard.fmul(0.010e18));
     }
 
     function testMainnetCantDeployAdapterIfNotSupportedTarget() public {

--- a/pkg/core/src/tests/factories/FFactory.tm.sol
+++ b/pkg/core/src/tests/factories/FFactory.tm.sol
@@ -25,6 +25,7 @@ contract FAdapterTestHelper is DSTest {
     uint256 public constant STAKE_SIZE = 1e18;
     uint256 public constant MIN_MATURITY = 2 weeks;
     uint256 public constant MAX_MATURITY = 14 weeks;
+    uint256 public constant DEFAULT_GUARD = 100000 * 1e18;
 
     function setUp() public {
         tokenHandler = new TokenHandler();
@@ -43,7 +44,8 @@ contract FAdapterTestHelper is DSTest {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
-            tilt: 0
+            tilt: 0,
+            guard: DEFAULT_GUARD
         });
         factory = new FFactory(address(divider), factoryParams);
         divider.setIsTrusted(address(factory), true); // add factory as a ward
@@ -60,7 +62,8 @@ contract FFactories is FAdapterTestHelper {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
-            tilt: 0
+            tilt: 0,
+            guard: DEFAULT_GUARD
         });
         FFactory otherFFactory = new FFactory(address(divider), factoryParams);
 
@@ -73,7 +76,8 @@ contract FFactories is FAdapterTestHelper {
             uint256 maxm,
             uint256 ifee,
             uint16 mode,
-            uint64 tilt
+            uint64 tilt,
+            uint256 guard
         ) = FFactory(otherFFactory).factoryParams();
 
         assertEq(FFactory(otherFFactory).divider(), address(divider));
@@ -85,6 +89,7 @@ contract FFactories is FAdapterTestHelper {
         assertEq(mode, MODE);
         assertEq(oracle, AddressBook.RARI_ORACLE);
         assertEq(tilt, 0);
+        assertEq(guard, DEFAULT_GUARD);
     }
 
     function testMainnetDeployAdapter() public {

--- a/pkg/core/src/tests/factories/FFactory.tm.sol
+++ b/pkg/core/src/tests/factories/FFactory.tm.sol
@@ -108,6 +108,9 @@ contract FFactories is FAdapterTestHelper {
 
         uint256 scale = FAdapter(adapter).scale();
         assertGt(scale, 0);
+
+        (, , uint256 guard, ) = divider.adapterMeta(address(adapter));
+        assertGt(guard, 0);
     }
 
     function testMainnetCantDeployAdapterIfInvalidComptroller() public {

--- a/pkg/core/src/tests/test-helpers/Constants.sol
+++ b/pkg/core/src/tests/test-helpers/Constants.sol
@@ -12,4 +12,5 @@ library Constants {
     uint16 public constant DEFAULT_TILT = 0;
     uint16 public constant DEFAULT_MODE = 0;
     uint64 public constant DEFAULT_ISSUANCE_FEE = 0.05e18;
+    uint256 public constant DEFAULT_GUARD = 100000 * 1e18;
 }

--- a/pkg/core/src/tests/test-helpers/TestHelper.sol
+++ b/pkg/core/src/tests/test-helpers/TestHelper.sol
@@ -103,6 +103,7 @@ contract TestHelper is DSTest {
     uint256 public MAX_MATURITY = 14 weeks;
     uint16 public DEFAULT_LEVEL = 31;
     uint16 public DEFAULT_TILT = 0;
+    uint256 public DEFAULT_GUARD = 100000 * 1e18; // guard in target terms
     uint256 public SPONSOR_WINDOW;
     uint256 public SETTLEMENT_WINDOW;
     uint256 public SCALING_FACTOR;
@@ -316,7 +317,8 @@ contract TestHelper is DSTest {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
-            tilt: 0
+            tilt: 0,
+            guard: DEFAULT_GUARD
         });
         if (is4626) {
             someFactory = address(new Mock4626CropFactory(address(divider), factoryParams, _reward));
@@ -337,7 +339,8 @@ contract TestHelper is DSTest {
             minm: MIN_MATURITY,
             maxm: 52 weeks,
             mode: MODE,
-            tilt: 0
+            tilt: 0,
+            guard: DEFAULT_GUARD
         });
         if (is4626) {
             someFactory = address(new Mock4626CropsFactory(address(divider), factoryParams, _rewardTokens));

--- a/pkg/core/src/tests/test-helpers/TestHelper.sol
+++ b/pkg/core/src/tests/test-helpers/TestHelper.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.11;
 
 // Internal references
 import { Divider, TokenHandler } from "../../Divider.sol";
-import { BaseFactory } from "../../adapters/abstract/factories/BaseFactory.sol";
+import { BaseFactory, ChainlinkOracleLike } from "../../adapters/abstract/factories/BaseFactory.sol";
 import { BaseAdapter } from "../../adapters/abstract/BaseAdapter.sol";
 import { PoolManager } from "@sense-finance/v1-fuse/src/PoolManager.sol";
 import { Token } from "../../tokens/Token.sol";
@@ -15,6 +15,7 @@ import { MockERC4626 } from "@rari-capital/solmate/src/test/utils/mocks/MockERC4
 import { ERC4626Adapter } from "../../adapters/abstract/ERC4626Adapter.sol";
 import { MockFactory, Mock4626CropFactory, MockCropsFactory, Mock4626CropsFactory } from "./mocks/MockFactory.sol";
 import { ERC20 } from "@rari-capital/solmate/src/tokens/ERC20.sol";
+import { AddressBook } from "./AddressBook.sol";
 
 // Space & Balanacer V2 mock
 import { MockSpaceFactory, MockBalancerVault } from "./mocks/MockSpace.sol";
@@ -222,6 +223,13 @@ contract TestHelper is DSTest {
             level: DEFAULT_LEVEL
         });
 
+        // mock all calls to Chainlink oracle
+        uint256 price = 1e8;
+        bytes memory returnData = abi.encode(1, int256(price), block.timestamp, block.timestamp, 1); // return data
+        ChainlinkOracleLike oracle = ChainlinkOracleLike(AddressBook.ETH_USD_PRICEFEED);
+        hevm.mockCall(address(address(oracle)), abi.encodeWithSelector(oracle.latestRoundData.selector), returnData);
+
+        // factories
         factory = MockFactory(deployFactory(address(target), address(reward)));
         address f = periphery.deployAdapter(address(factory), address(target), ""); // deploy & onboard target through Periphery
         adapter = MockAdapter(f);

--- a/pkg/core/src/tests/test-helpers/TestHelper.sol
+++ b/pkg/core/src/tests/test-helpers/TestHelper.sol
@@ -16,6 +16,7 @@ import { ERC4626Adapter } from "../../adapters/abstract/ERC4626Adapter.sol";
 import { MockFactory, Mock4626CropFactory, MockCropsFactory, Mock4626CropsFactory } from "./mocks/MockFactory.sol";
 import { ERC20 } from "@rari-capital/solmate/src/tokens/ERC20.sol";
 import { AddressBook } from "./AddressBook.sol";
+import { PriceOracleLike } from "../../adapters/abstract/ERC4626Adapter.sol";
 
 // Space & Balanacer V2 mock
 import { MockSpaceFactory, MockBalancerVault } from "./mocks/MockSpace.sol";
@@ -228,6 +229,14 @@ contract TestHelper is DSTest {
         bytes memory returnData = abi.encode(1, int256(price), block.timestamp, block.timestamp, 1); // return data
         ChainlinkOracleLike oracle = ChainlinkOracleLike(AddressBook.ETH_USD_PRICEFEED);
         hevm.mockCall(address(address(oracle)), abi.encodeWithSelector(oracle.latestRoundData.selector), returnData);
+
+        // mock all calls to oracle price
+        returnData = abi.encode(1e18); // return data
+        hevm.mockCall(
+            address(ORACLE),
+            abi.encodeWithSelector(PriceOracleLike(ORACLE).price.selector, address(underlying)),
+            returnData
+        );
 
         // factories
         factory = MockFactory(deployFactory(address(target), address(reward)));

--- a/pkg/core/src/tests/test-helpers/mocks/MockFactory.sol
+++ b/pkg/core/src/tests/test-helpers/mocks/MockFactory.sol
@@ -33,7 +33,7 @@ contract MockFactory is CropFactory {
         targets[_target] = status;
     }
 
-    function deployAdapter(address _target, bytes memory data) external override returns (address adapter) {
+    function deployAdapter(address _target, bytes memory data) external virtual override returns (address adapter) {
         if (!targets[_target]) revert Errors.TargetNotSupported();
         if (Divider(divider).periphery() != msg.sender) revert Errors.OnlyPeriphery();
 

--- a/pkg/core/src/tests/test-helpers/mocks/MockFactory.sol
+++ b/pkg/core/src/tests/test-helpers/mocks/MockFactory.sol
@@ -61,6 +61,8 @@ contract MockFactory is CropFactory {
                 reward
             )
         );
+
+        _setGuard(adapter);
     }
 }
 
@@ -108,6 +110,8 @@ contract Mock4626CropFactory is CropFactory {
                 reward
             )
         );
+
+        _setGuard(adapter);
     }
 }
 
@@ -157,6 +161,8 @@ contract MockCropsFactory is CropsFactory {
                 rewardTokens
             )
         );
+
+        _setGuard(adapter);
     }
 }
 
@@ -206,5 +212,7 @@ contract Mock4626CropsFactory is CropsFactory {
                 rewardTokens
             )
         );
+
+        _setGuard(adapter);
     }
 }

--- a/pkg/deployments/deploy/prod/04-factories.js
+++ b/pkg/deployments/deploy/prod/04-factories.js
@@ -15,13 +15,13 @@ module.exports = async function () {
   log("DEPLOY FACTORIES & ADAPTERS");
   log("-------------------------------------------------------");
   for (let factory of global.mainnet.FACTORIES) {
-    const { contractName, adapterContract, oracle, stake, stakeSize, minm, maxm, ifee, mode, tilt, reward, targets, crops } =
+    const { contractName, adapterContract, oracle, stake, stakeSize, minm, maxm, ifee, mode, tilt, reward, targets, crops, guard } =
       factory(chainId);
     if (!crops && !reward) throw Error("No reward token found");
     if (!stake) throw Error("No stake token found");
 
     log(`\nDeploy ${contractName}`);
-    const factoryParams = [oracle, stake, stakeSize, minm, maxm, ifee, mode, tilt];
+    const factoryParams = [oracle, stake, stakeSize, minm, maxm, ifee, mode, tilt, guard];
     const { address: factoryAddress } = await deploy(contractName, {
       from: deployer,
       args: [divider.address, factoryParams, ...(!crops ? [reward] : [])],

--- a/pkg/deployments/deploy/simulated/04-adapters.js
+++ b/pkg/deployments/deploy/simulated/04-adapters.js
@@ -32,10 +32,10 @@ module.exports = async function () {
   });
 
   for (let factory of global.dev.FACTORIES) {
-    const { contractName: factoryContractName, oracle, stakeSize, minm, maxm, ifee, mode, tilt, targets, crops, is4626 } = factory(chainId);
+    const { contractName: factoryContractName, oracle, stakeSize, minm, maxm, ifee, mode, tilt, targets, crops, is4626, guard } = factory(chainId);
     log(`\nDeploy ${factoryContractName} with mocked dependencies`);
     // Large enough to not be a problem, but won't overflow on ModAdapter.fmul
-    const factoryParams = [oracle, stake.address, stakeSize, minm, maxm, ifee, mode, tilt];
+    const factoryParams = [oracle, stake.address, stakeSize, minm, maxm, ifee, mode, tilt, guard];
     const { address: mockFactoryAddress } = await deploy(factoryContractName, {
       from: deployer,
       args: [divider.address, factoryParams, crops ? [airdrop.address] : airdrop.address],

--- a/pkg/deployments/hardhat.seed.js
+++ b/pkg/deployments/hardhat.seed.js
@@ -115,7 +115,8 @@ const DEV_FACTORIES = [
     tilt: 0,
     targets: DEV_TARGETS,
     crops: false,
-    is4626: false
+    is4626: false,
+    guard: ethers.utils.parseEther("100000")
   }),
   chainId => ({
     contractName: "MockCropsFactory",
@@ -128,7 +129,8 @@ const DEV_FACTORIES = [
     tilt: 0,
     targets: DEV_CROPS_TARGETS,
     crops: true,
-    is4626: false
+    is4626: false,
+    guard: ethers.utils.parseEther("100000")
   }),
   chainId => ({
     contractName: "Mock4626CropFactory",
@@ -142,6 +144,7 @@ const DEV_FACTORIES = [
     targets: DEV_4626_TARGETS,
     crops: false,
     is4626: true,
+    guard: ethers.utils.parseEther("100000")
   }),
   chainId => ({
     contractName: "Mock4626CropsFactory",
@@ -154,7 +157,8 @@ const DEV_FACTORIES = [
     tilt: 0,
     targets: DEV_4626_CROPS_TARGETS,
     crops: true,
-    is4626: true
+    is4626: true,
+    guard: ethers.utils.parseEther("100000")
   }),
 ];
 // ------------------------------------
@@ -190,6 +194,7 @@ const MAINNET_FACTORIES = [
     reward: COMP_TOKEN.get(chainId),
     targets: CTARGETS(chainId),
     crops: false,
+    guard: ethers.utils.parseEther("100000"),
   }),
   // FFactory example
   chainId => ({
@@ -205,6 +210,7 @@ const MAINNET_FACTORIES = [
     tilt: 0,
     targets: FTARGETS(chainId),
     crops: true,
+    guard: ethers.utils.parseEther("100000"),
   }),
 ];
 


### PR DESCRIPTION
## Motivation

When deploying adapters via factories, we need to automatically set the guard. Otherwise, these adapters won't be able to issue until `guarded` is set to `false` or until admins set a guard.

## Solution

On `deployAdapter()`, make a call to set the guard. 

## Implementer Checklist

<!--
Fill out the checklist below as applicable to your change. Bug fixes and new features must 
check off all of the required items.
-->


- [ ]  [FIRST TIME ONLY] Review the [Solcurity](https://github.com/Rari-Capital/solcurity) standard
- [ ]  [OPTIONAL] Create a reference implementation (in python or JS)
- [x]  Create a short "Motivation" section for the PR
- [x]  Write a spec for the feature and put it in the PR description – basic function names and expected state transitions is OK
- [ ]  Check all of the new revert paths with concrete tests
- [ ]  Check all of the new storage slot writes with concrete tests – do not make the passing test case the trivial case!
- [ ]  Go line-by-line through the new code and ensure it has all been covered by concrete tests – since we don’t have a coverage engine for foundry yet, you can imagine how one might check that each different code path is covered
- [ ]  Simplify the implementation and spend some time trying to minimize gas costs
- [ ]  Write fuzz tests for the feature – try everything to break the implementation (is this function monotonically in/decreasing, should it always be less than something else, etc)
- [ ]  Capture bugs discovered during the above steps in concrete tests (regression tests)
- [ ]  Add integration tests – fuzz or concrete tests that test how the new code affects the entire system, either locally or with a mainnet fork
- [ ]  [OPTIONAL] Integrate the feature into the deployment scripts
- [ ]  [OPTIONAL] Add new sanity checks to the deployment scripts
- [ ]  Get the PR reviewed by at least two people