### PR TITLE
refactor(yt-buying-lib): enable initial space conditions and factor scale in correctly

### DIFF
--- a/yt-buying-lib/index.js
+++ b/yt-buying-lib/index.js
@@ -46,7 +46,7 @@ export class SpaceFluxer {
     return targetOut;
   }
 
-  // Create a function to a YT buy and return the amount of Target remaining at the end
+  // Create a function to make a YT buy and return the amount of Target remaining at the end
   _getYTBuyer(initialTarget, optimalTargetReturned) {
     const exponent = parseInt(Number.parseFloat(initialTarget).toExponential(0).split("e")[1]);
     // Set multiplier on the minimization function so that we get precise results, even with small target in values


### PR DESCRIPTION

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

We got an external request for this library, so I wanted to make sure it was flexible and correct

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Add the new features from the version of this library in the frontend while maintaining the previous ability to bootstrap the fluxer without a live space pool for data. In addition, add the optimize function into the fluxer directly (rather than assuming the user will bring their own optimization lib)

