### PR TITLE
GEN-1151: Ribbon adapter

### DIFF
--- a/pkg/core/src/adapters/implementations/ribbon/RAdapter.sol
+++ b/pkg/core/src/adapters/implementations/ribbon/RAdapter.sol
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.11;
+
+// External references
+import { ERC20 } from "@rari-capital/solmate/src/tokens/ERC20.sol";
+import { MockToken } from "../../../tests/test-helpers/mocks/MockToken.sol"; // TODO: replace for MintableToken interface
+import { ERC4626 } from "@rari-capital/solmate/src/mixins/ERC4626.sol";
+import { SafeTransferLib } from "@rari-capital/solmate/src/utils/SafeTransferLib.sol";
+
+// Internal references
+import { Errors } from "@sense-finance/v1-utils/src/libs/Errors.sol";
+import { BaseAdapter } from "../../abstract/BaseAdapter.sol";
+import { FixedMath } from "../../../external/FixedMath.sol";
+
+interface WETHLike {
+    function deposit() external payable;
+
+    function withdraw(uint256 wad) external;
+}
+
+interface RTokenLike {
+    function pricePerShare() external view returns (uint256);
+
+    function roundPricePerShare(uint256) external view returns (uint256);
+
+    function decimals() external view returns (uint8);
+
+    function underlying() external view returns (address);
+
+    function vaultParams()
+        external
+        view
+        returns (
+            bool,
+            uint8,
+            address,
+            address,
+            uint56,
+            uint104
+        );
+
+    function vaultState()
+        external
+        view
+        returns (
+            uint16,
+            uint104,
+            uint104,
+            uint128,
+            uint128
+        );
+
+    function depositETH() external payable; // RETH only
+
+    function depositYieldToken(uint256) external payable;
+
+    function maxRedeem() external payable;
+
+    function completeWithdraw() external;
+
+    function withdrawInstantly(uint256 amount, uint256) external;
+
+    function initiateWithdraw(uint256 numShares) external;
+
+    function depositReceipts(address)
+        external
+        returns (
+            uint16 round,
+            uint104 amount,
+            uint128 unredeemedShares
+        );
+}
+
+interface PriceOracleLike {
+    function getPrice(address _asset) external view returns (uint256);
+}
+
+/// @notice Adapter contract for fTokens
+contract RAdapter is BaseAdapter {
+    using SafeTransferLib for ERC20;
+    using FixedMath for uint256;
+
+    address public constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+    address public constant FETH = 0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5;
+    address public constant STETH = 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84;
+
+    address public immutable rToken;
+    address public immutable target2;
+    bool public immutable isRETH;
+    uint8 public immutable uDecimals;
+
+    constructor(
+        address _divider,
+        address _target,
+        address _target2,
+        address _underlying,
+        address _rToken, // TODO: remove from here? and do `ERC4626(_target).asset()`;
+        uint128 _ifee,
+        AdapterParams memory _adapterParams
+    ) BaseAdapter(_divider, _target, _underlying, _ifee, _adapterParams) {
+        isRETH = _underlying == WETH; // TODO: use this udnerlying or _underlying??
+        rToken = _rToken;
+        target2 = _target2;
+
+        ERC20(underlying).approve(rToken, type(uint256).max);
+        uDecimals = ERC20(_underlying).decimals(); // TODO: use decimals from vaultParams?
+    }
+
+    function notify(
+        address _usr,
+        uint256 amt,
+        bool join
+    ) public override(BaseAdapter) {
+        super.notify(_usr, amt, join);
+    }
+
+    /// @return Exchange rate from Target to Underlying using Ribbon's `pricePerShare()`, normed to 18 decimals
+    function scale() external override returns (uint256) {
+        uint256 exRate = RTokenLike(rToken).pricePerShare();
+        return _to18Decimals(exRate);
+    }
+
+    function scaleStored() external view override returns (uint256) {
+        uint256 exRate = RTokenLike(rToken).pricePerShare();
+        return _to18Decimals(exRate);
+    }
+
+    function getUnderlyingPrice() external view override returns (uint256 price) {
+        price = isRETH ? 1e18 : PriceOracleLike(adapterParams.oracle).getPrice(underlying);
+    }
+
+    /// @dev When wrapping underlying, we mint wrapped target tokens and send them to the user
+    /// This is because Ribbon does not retun target immediately after a deposit is made
+    /// The underlying is sent to Ribbon and stays as pending amount until the next round starts
+    function wrapUnderlying(uint256 uBal) external override returns (uint256 tBal) {
+        ERC20(underlying).safeTransferFrom(msg.sender, address(this), uBal); // pull underlying
+
+        // Deposit underlying on Ribbon
+        // TODO: de we want to allow deposits directly in ETH?
+        // TODO: check if to use depositYieldToken, depositFor or deposit (deposit does not exist for example on the RSTETH)
+        if (isRETH) {
+            WETHLike(WETH).withdraw(uBal); // unwrap WETH into ETH
+            RTokenLike(rToken).depositETH{ value: uBal }();
+        } else {
+            RTokenLike(rToken).depositYieldToken(uBal);
+        }
+
+        uint256 pps = RTokenLike(rToken).pricePerShare();
+        tBal = uBal.fdiv(pps);
+
+        // if (underlying == STETH) tBal -= 1; // because stETH transfers suffer from an off-by-1 error (from RibbonVault.sol line 343) // TODO: do we need this?
+        MockToken(target).mint(msg.sender, tBal); // mint wrapped target
+    }
+
+    /// @notice Unwrapping target is a 2-step process: `initiateUnwrapTarget` (see below) and `unwrapTarget` (line 224)
+    /// `initiateUnwrapTarget` will:
+    /// - pull user's wrapped target tokens (wTarget)
+    /// - calculate how much those wTarget represent in Ribbon target (rTarget).
+    /// - call Ribbon to initiate withdraw passing the rTarget amount
+    /// - burn wTarget
+    ///
+    /// @dev when initiating an unwrap, we *check* (line 197) the pending underlying available in Ribbon
+    /// and, if this amount is less or equal than the amount the user wants to unwrap
+    /// we trigger a `withdrawInstantly` in Ribbon. We are doing this because of the following scenario:
+    // - User A calls wrapUnderlying -> we mint wTarget at current pps
+    // - ROUND CLOSES
+    // - User B calls wrapUnderlying -> we mint wTarget at current pps
+    // - User B calls `initiateUnwrapTarget` (without waiting for the round to be closed)
+    // - - If we are not doing the *check* mentioned before and just trigger an `initiateWithdraw` in Ribbon,
+    // we will starting a withdraw of rTarget frorm Ribbon while we should have been just withdrawing the
+    // pending underlying and this will be conflicting with other user's positions that didn't want to intiate any withdrawal.
+    function initiateUnwrapTarget(uint256 wtBal) external {
+        (, uint104 pendingUnderlying, ) = RTokenLike(rToken).depositReceipts(address(this));
+        RTokenLike(rToken).maxRedeem(); // TODO: maybe we can skip this and use unredeemShares?
+
+        uint256 totalUnderlyingAvailable = pendingUnderlying + ERC20(underlying).balanceOf(address(this));
+        uint256 totalTarget = ERC20(rToken).balanceOf(address(this));
+
+        // total underlying is the sum of the pending underlying in Ribbon + any existing underlying balance in the adapter
+        // + the adapter's target balance converted to underlying
+        //
+        // FIXME: the issue here is when trying to convert the total wrapped target tokens to underlying
+        // because some of the total wTarget are backed by underlying and some by target. To calculate
+        // the target-underlying conversion, we would probably need the pps of the previous round of each user's
+        // deposit (which we don't have).
+        // Below, we are using the current pps which is a higher one, making the target-underlying conversion
+        // to give us more underlying which will give us a higher `totalUnderlying` number and the user will get more
+        // than what he should.
+        uint256 totalUnderlying = totalUnderlyingAvailable + totalTarget.fmul(RTokenLike(rToken).pricePerShare());
+
+        // calculate how much underlying the wtBal represents (based on the totalUnderlying)
+        uint256 totalSupply = MockToken(target).totalSupply();
+        uint256 share = wtBal.fdiv(totalSupply, FixedMath.RAY);
+        uint256 uBal = share.fmul(totalUnderlying, FixedMath.RAY);
+
+        // A user might get an instant withdraw but this is not in every case
+        if (uBal <= totalUnderlyingAvailable) {
+            // Withdraw underlying
+            RTokenLike(rToken).withdrawInstantly(uBal, 0);
+            ERC20(underlying).transfer(msg.sender, uBal);
+        } else {
+            // calculate how much target the wtBal represent
+            totalSupply = MockToken(target).totalSupply();
+            share = wtBal.fdiv(totalSupply, FixedMath.RAY);
+            uint256 tBal = share.fmul(totalTarget, FixedMath.RAY);
+
+            // Mint wrapped target tokens 2
+            MockToken(target2).mint(msg.sender, tBal);
+
+            // Initiate withdrawal
+            RTokenLike(rToken).initiateWithdraw(tBal);
+        }
+
+        // Burn wrapped target tokens
+        MockToken(target).burn(msg.sender, wtBal);
+    }
+
+    /// `unwrapTarget` is the 2nd step:
+    /// - pulls the user's wrapped target tokens 2
+    /// - calls `ribbon.completeWithdraw` which sends underlying back to the adapter
+    /// - calculates how much those wrapped target 2 represent in underlying
+    /// - burns wrapped target 2
+    /// - transfers underlying to user
+    function unwrapTarget(uint256 wt2Bal) external override returns (uint256 uBal) {
+        // Complete withdraw on Ribbon (will send underlying back)
+        RTokenLike(rToken).completeWithdraw();
+
+        // Calculate how much underlying the wt2Bal represent
+        uint256 totalUnderlying = ERC20(underlying).balanceOf(address(this));
+        uint256 totalSupply = MockToken(target2).totalSupply();
+        uint256 share = wt2Bal.fdiv(totalSupply, FixedMath.RAY);
+        uBal = share.fmul(totalUnderlying, FixedMath.RAY);
+
+        if (isRETH) {
+            // Deposit ETH into WETH contract
+            (bool success, ) = WETH.call{ value: uBal }("");
+            if (!success) revert Errors.TransferFailed();
+        }
+
+        // Burn wrapped target tokens
+        MockToken(target2).burn(msg.sender, wt2Bal);
+
+        // Transfer underlying to sender
+        ERC20(underlying).safeTransfer(msg.sender, uBal);
+    }
+
+    event Log(uint256);
+
+    function _to18Decimals(uint256 exRate) internal view returns (uint256) {
+        // "pricePerShare() returns the price of a unit of share denominated in the `asset`
+        // (using the decicmals of the asset)
+
+        // The equation to norm an asset to 18 decimals is:
+        // `num * 10**(18 - decimals)`
+        return uDecimals >= 18 ? exRate / 10**(uDecimals - 18) : exRate * 10**(18 - uDecimals);
+    }
+
+    /* ========== FALLBACK ========== */
+
+    fallback() external payable {}
+}

--- a/pkg/core/src/tests/adapters/RAdapter.tm.sol
+++ b/pkg/core/src/tests/adapters/RAdapter.tm.sol
@@ -1,0 +1,376 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.11;
+
+import { FixedMath } from "../../external/FixedMath.sol";
+import { ERC20 } from "@rari-capital/solmate/src/tokens/ERC20.sol";
+import { ERC4626 } from "@rari-capital/solmate/src/mixins/ERC4626.sol";
+import { MockERC4626 } from "@rari-capital/solmate/src/test/utils/mocks/MockERC4626.sol";
+import { MockToken } from "../test-helpers/mocks/MockToken.sol"; // TODO: replace for RWRAPPER
+import { SafeTransferLib } from "@rari-capital/solmate/src/utils/SafeTransferLib.sol";
+
+// Internal references
+import { Divider, TokenHandler } from "../../Divider.sol";
+import { RAdapter, WETHLike, RTokenLike } from "../../adapters/implementations/ribbon/RAdapter.sol";
+import { BaseAdapter } from "../../adapters/abstract/BaseAdapter.sol";
+
+import { AddressBook } from "../test-helpers/AddressBook.sol";
+import { DSTest } from "../test-helpers/test.sol";
+import { Hevm } from "../test-helpers/Hevm.sol";
+import { DateTimeFull } from "../test-helpers/DateTimeFull.sol";
+import { LiquidityHelper } from "../test-helpers/LiquidityHelper.sol";
+
+interface RTokenLikePlus is RTokenLike {
+    function rollToNextOption() external;
+
+    function keeper() external returns (address);
+
+    function commitAndClose() external;
+
+    function currentOption() external returns (address);
+
+    function setManagementFee(uint256 newManagementFee) external;
+
+    function setPerformanceFee(uint256 newPeformanceFee) external;
+
+    function owner() external returns (address);
+
+    // function depositReceipts() external returns (DepositReceipt memory receipt);
+    function depositReceipts(address)
+        external
+        returns (
+            uint16 round,
+            uint104 amount,
+            uint128 unredeemedShares
+        );
+
+    function totalBalance() external returns (uint256);
+
+    function optionAuctionID() external returns (uint256);
+
+    function GNOSIS_EASY_AUCTION() external returns (address);
+
+    struct DepositReceipt {
+        // Maximum of 65535 rounds. Assuming 1 round is 7 days, maximum is 1256 years.
+        uint16 round;
+        // Deposit amount, max 20,282,409,603,651 or 20 trillion ETH deposit
+        uint104 amount;
+        // Unredeemed shares balance
+        uint128 unredeemedShares;
+    }
+}
+
+interface OptionLike {
+    function expiryTimestamp() external returns (uint256);
+}
+
+interface EasyAuction {
+    function settleAuction(uint256 auctionId) external returns (bytes32 clearingOrder);
+
+    function auctionData(uint256 auctionId)
+        external
+        returns (
+            address,
+            address,
+            uint256,
+            uint256,
+            bytes32,
+            uint256,
+            uint256,
+            bytes32,
+            bytes32,
+            uint96,
+            bool,
+            bool,
+            uint256,
+            uint256
+        );
+}
+
+interface PriceOracleLike {
+    function setAssetPricer(address _asset, address _pricer) external;
+
+    function owner() external returns (address);
+
+    function setExpiryPrice(
+        address _asset,
+        uint256 _expiryTimestamp,
+        uint256 _price
+    ) external;
+
+    function getPrice(address _asset) external view returns (uint256);
+
+    function getPricer(address _asset) external view returns (address);
+
+    function setLockingPeriod(address _pricer, uint256 _lockingPeriod) external;
+
+    function setDisputePeriod(address _pricer, uint256 _disputePeriod) external;
+}
+
+interface StETHLike {
+    /// @notice Get amount of stETH for a one wstETH
+    function getPooledEthByShares(uint256 _sharesAmount) external view returns (uint256);
+
+    function submit(address _referral) external payable returns (uint256);
+}
+
+contract RAdapterTestHelper is LiquidityHelper, DSTest {
+    RAdapter internal rstETHAdapter; // Ribbon stETH Theta Adapter
+    RAdapter internal rBTCAdapter; // Ribbon wBTC Theta Adapter
+    Divider internal divider;
+    TokenHandler internal tokenHandler;
+
+    /// @notice rTokens take the decimals of the underlying
+    uint256 public constant ONE_RTOKEN = 1e18;
+    uint16 public constant DEFAULT_LEVEL = 31;
+    uint256 public constant INITIAL_BALANCE = 1.25e18;
+
+    uint16 public constant MODE = 0;
+    uint64 public constant ISSUANCE_FEE = 0.01e18;
+    uint256 public constant STAKE_SIZE = 1e18;
+    uint256 public constant MIN_MATURITY = 2 weeks;
+    uint256 public constant MAX_MATURITY = 14 weeks;
+
+    Hevm internal constant hevm = Hevm(HEVM_ADDRESS);
+
+    function setUp() public {
+        giveTokens(AddressBook.STETH, 100e18 + 1, hevm);
+
+        tokenHandler = new TokenHandler();
+        divider = new Divider(address(this), address(tokenHandler));
+        divider.setPeriphery(address(this));
+        tokenHandler.init(address(divider));
+
+        MockToken target = new MockToken(
+            "wrstETH-THETA",
+            "Wrapped stETH Theta Vault",
+            ERC20(AddressBook.RSTETH_THETA).decimals()
+        );
+        MockToken target2 = new MockToken(
+            "wrstETH-THETA2",
+            "Wrapped stETH Theta Vault 2",
+            ERC20(AddressBook.RSTETH_THETA).decimals()
+        );
+        (, , address asset, address underlying, , ) = RTokenLike(AddressBook.RSTETH_THETA).vaultParams();
+        BaseAdapter.AdapterParams memory adapterParams = BaseAdapter.AdapterParams({
+            oracle: AddressBook.OPYN_ORACLE,
+            stake: AddressBook.WETH,
+            stakeSize: STAKE_SIZE,
+            minm: MIN_MATURITY,
+            maxm: MAX_MATURITY,
+            mode: 0,
+            tilt: 0,
+            level: DEFAULT_LEVEL
+        });
+        rstETHAdapter = new RAdapter(
+            address(divider),
+            address(target),
+            address(target2),
+            // asset, // TODO: or use underlying var from vaultParams?
+            AddressBook.STETH, // TODO: where to get the underlying??
+            AddressBook.RSTETH_THETA,
+            ISSUANCE_FEE,
+            adapterParams
+        ); // Ribbon stETH Theta adapter
+
+        // Ribbon without fees
+        hevm.startPrank(RTokenLikePlus(rstETHAdapter.rToken()).owner());
+        RTokenLikePlus(rstETHAdapter.rToken()).setManagementFee(0);
+        RTokenLikePlus(rstETHAdapter.rToken()).setPerformanceFee(0);
+        hevm.stopPrank();
+
+        (, , asset, underlying, , ) = RTokenLike(AddressBook.RBTC_THETA).vaultParams();
+        rBTCAdapter = new RAdapter(
+            address(divider),
+            AddressBook.RBTC_THETA,
+            AddressBook.RBTC_THETA,
+            asset,
+            AddressBook.RBTC_THETA,
+            ISSUANCE_FEE,
+            adapterParams
+        ); // Ribbon BTC adapter
+    }
+}
+
+contract RAdapters is RAdapterTestHelper {
+    using FixedMath for uint256;
+
+    function testMainnetRAdapterScale() public {
+        // rstETH scale
+        RTokenLike underlying = RTokenLike(AddressBook.WETH);
+        RTokenLike rtoken = RTokenLike(AddressBook.RSTETH_THETA);
+
+        uint256 uDecimals = underlying.decimals();
+        uint256 scale = rtoken.pricePerShare() / 10**(uDecimals - 8);
+        assertEq(rstETHAdapter.scale(), scale);
+
+        // rBTC scale
+        underlying = RTokenLike(AddressBook.WBTC);
+        rtoken = RTokenLike(AddressBook.RBTC_THETA);
+
+        uDecimals = underlying.decimals();
+        scale = rtoken.pricePerShare() / 10**(uDecimals - 8);
+        assertEq(rBTCAdapter.scale(), scale);
+    }
+
+    function testMainnetGetUnderlyingPrice() public {
+        PriceOracleLike oracle = PriceOracleLike(AddressBook.OPYN_ORACLE);
+        uint256 price = oracle.getPrice(AddressBook.WBTC);
+        assertEq(rBTCAdapter.getUnderlyingPrice(), price);
+    }
+
+    function testMainnetCantUnwrapTargetIfNotInitiated() public {
+        ERC20(AddressBook.RSTETH_THETA).approve(address(rstETHAdapter), type(uint256).max);
+        hevm.expectRevert("Not initiated");
+        rstETHAdapter.unwrapTarget(1e18);
+    }
+
+    function testMainnetUnwrapTarget() public {
+        ERC20 wTarget = ERC20(rstETHAdapter.target());
+        ERC20 w2Target = ERC20(rstETHAdapter.target2());
+        ERC20 target = ERC20(rstETHAdapter.rToken());
+        ERC20 underlying = ERC20(AddressBook.STETH);
+
+        // User has no wrapped target
+        assertEq(0, wTarget.balanceOf(address(this)));
+
+        // Approve adapter to pull user's underlying
+        ERC20(AddressBook.STETH).approve(address(rstETHAdapter), type(uint256).max);
+
+        // Wrap underlying
+        uint256 uBalanceBefore = ERC20(AddressBook.STETH).balanceOf(address(this));
+        uint256 wrappedAmt = rstETHAdapter.wrapUnderlying(uBalanceBefore);
+
+        // Wrapped target balance should be equal to underlying / price per share
+        uint256 wtBalanceBefore = wTarget.balanceOf(address(this));
+        uint256 pps = RTokenLike(AddressBook.RSTETH_THETA).pricePerShare();
+        assertEq(wtBalanceBefore, uBalanceBefore.fdiv(pps));
+        assertEq(wtBalanceBefore, wrappedAmt);
+
+        // Perform some actions on Opyn so as to be able to close the current round
+        // and start the next one
+        closeRound();
+
+        // Initiate withdrawal (will pull user's target)
+        wTarget.approve(address(rstETHAdapter), wtBalanceBefore);
+        rstETHAdapter.initiateUnwrapTarget(wtBalanceBefore);
+        assertEq(wTarget.balanceOf(msg.sender), 0);
+        // assert totalSupply decreased
+        // assert totalSupply of wtarget 2 increased
+
+        uint256 wtBalanceAfter = wTarget.balanceOf(address(this));
+        assertEq(wtBalanceAfter, 0);
+
+        closeRound();
+
+        uint256 wt2BalanceBefore = w2Target.balanceOf(address(this));
+        uint256 unwrappedAmt = rstETHAdapter.unwrapTarget(wt2BalanceBefore);
+        uint256 wt2BalanceAfter = w2Target.balanceOf(address(this));
+        assertEq(wt2BalanceAfter, 0);
+
+        uint256 uBalanceAfter = underlying.balanceOf(address(this));
+        assertEq(uBalanceAfter, unwrappedAmt);
+        // assertEq(uBalanceBefore + unwrapped, uBalanceAfter); // TODO: assert
+    }
+
+    // Test case: adapter has target form other user deposits from active rounds.
+    // Alice makes a new deposits and tries withdrawing before her deposit got into
+    // the next round. This should NOT trigger an initiate withdraw on Ribbon.
+    // In the example above:
+    // - 1st user makes a deposit of 100 steth
+    // - round is closed
+    // - Alice makes a deposit of 100 steth
+    // - Alice tries initiating a withdrawal
+    // `initiateUnwrapTarget` is triggering an instant withdraw (which is fine)
+    // because the available underlying is enough to cover the withdrawal amount of Alice.
+    // But, somehow, we are sending back to Alice a bit less than the underlying she deposited.
+    // TODO: we need to understand why
+    function testMainnetUnwrapTargetWhenWrappedTargetNotReachedRound() public {
+        ERC20 wTarget = ERC20(rstETHAdapter.target());
+        ERC20 w2Target = ERC20(rstETHAdapter.target2());
+        ERC20 target = ERC20(rstETHAdapter.rToken());
+        ERC20 underlying = ERC20(AddressBook.STETH);
+
+        // Wrap underlying (STETH)
+        uint256 pps = RTokenLike(AddressBook.RSTETH_THETA).roundPricePerShare(38);
+        uint256 uBalanceBefore = ERC20(AddressBook.STETH).balanceOf(address(this));
+        ERC20(AddressBook.STETH).approve(address(rstETHAdapter), uBalanceBefore);
+        rstETHAdapter.wrapUnderlying(uBalanceBefore);
+
+        closeRound();
+
+        // Fund Alice wallet with underlying
+        hevm.label(address(123), "Alice");
+        giveTokens(AddressBook.STETH, address(123), 100e18 + 1, hevm);
+
+        // Prank Alice on next calls
+        hevm.startPrank(address(123));
+
+        // Alice wraps underlying (on the new round)
+        uBalanceBefore = ERC20(AddressBook.STETH).balanceOf(address(123));
+        ERC20(AddressBook.STETH).approve(address(rstETHAdapter), uBalanceBefore);
+        uint256 wtBal = rstETHAdapter.wrapUnderlying(uBalanceBefore);
+        RTokenLike(AddressBook.RSTETH_THETA).pricePerShare();
+
+        // Alice initiates a withdrawal (note that she didn't wait for the round to start)
+        // so the instantWithdraw should have been triggered
+        wTarget.approve(address(rstETHAdapter), wtBal);
+        rstETHAdapter.initiateUnwrapTarget(wtBal, pps);
+
+        hevm.stopPrank();
+
+        // FIXME
+        assertEq(uBalanceBefore, ERC20(AddressBook.STETH).balanceOf(address(123)));
+    }
+
+    // Perform some actions on Ribbon and Opyn so as to be able to close the current round
+    // and start the next one
+    function closeRound() internal {
+        // Set expiry prices on Opyn for the relevant assets involved (WETH, WSTETH)
+        OptionLike option = OptionLike(RTokenLikePlus(AddressBook.RSTETH_THETA).currentOption());
+        uint256 expiryTimestamp = option.expiryTimestamp();
+        PriceOracleLike oracle = PriceOracleLike(AddressBook.OPYN_ORACLE); // Or get from option.controller().getConfiguration() 2nd param
+
+        uint256 wethPrice = oracle.getPrice(AddressBook.WETH);
+        address wethPricer = oracle.getPricer(AddressBook.WETH); // underlyingAsset pricer
+
+        uint256 wstEthPrice = oracle.getPrice(AddressBook.WSTETH);
+        address wstEthPricer = oracle.getPricer(AddressBook.WSTETH); // collateralAsset pricer
+
+        // Set pricers locking and dispute periods to 0
+        hevm.startPrank(oracle.owner());
+        oracle.setLockingPeriod(wethPricer, 0);
+        oracle.setDisputePeriod(wethPricer, 0);
+        oracle.setLockingPeriod(wstEthPricer, 0);
+        oracle.setDisputePeriod(wstEthPricer, 0);
+        hevm.stopPrank();
+
+        // Fast forward to expiry date (Friday 8am UTC)
+        hevm.warp(expiryTimestamp + 1);
+
+        // Set WETH and WSTETH prices for the expiry date
+        hevm.prank(wethPricer);
+        // https://etherscan.io/tx/0x05ec31825a6247cace4086dac3ee01b7c49d0d722c873c19a2b46a86413005dd
+        // oracle.setExpiryPrice(AddressBook.WETH, expiryTimestamp, 1659081600);
+        oracle.setExpiryPrice(AddressBook.WETH, expiryTimestamp, wethPrice);
+        hevm.prank(wstEthPricer);
+        // https://etherscan.io/tx/0xe840a801fa9d77de448dd5d06193306be0b745eb68472eef7be45f0a77acfcc6
+        // oracle.setExpiryPrice(AddressBook.WSTETH, expiryTimestamp, 1659081600);
+        oracle.setExpiryPrice(AddressBook.WSTETH, expiryTimestamp, wstEthPrice);
+
+        // Commit and close
+        hevm.warp(expiryTimestamp + 2);
+        // https://etherscan.io/tx/0xeac31cf639fc217e384da2cc9ae10962594f4a56a7cc356a4b38977d0a1cae5e
+        RTokenLikePlus(AddressBook.RSTETH_THETA).commitAndClose();
+
+        // Impersonate keeper so we can call `rollToNextOption` to close this current round
+        hevm.prank(RTokenLikePlus(AddressBook.RSTETH_THETA).keeper());
+        // https://etherscan.io/tx/0x9ff72095d4c4152d329fb8924e6c3fafcb3027991f5be605c229f019b4c55808
+        RTokenLikePlus(AddressBook.RSTETH_THETA).rollToNextOption();
+
+        // uint256 optionAuctionId = RTokenLikePlus(AddressBook.RSTETH_THETA).optionAuctionID();
+        // address easyAuction = RTokenLikePlus(AddressBook.RSTETH_THETA).GNOSIS_EASY_AUCTION();
+        // get EasyAuction from RTokenLikePlus
+        // EasyAuction(easyAuction).auctionData(optionAuctionId);
+        // EasyAuction(easyAuction).settleAuction(optionAuctionId);
+    }
+}

--- a/pkg/core/src/tests/test-helpers/AddressBook.sol
+++ b/pkg/core/src/tests/test-helpers/AddressBook.sol
@@ -11,6 +11,7 @@ library AddressBook {
     address public constant CRV = 0xD533a949740bb3306d119CC777fa900bA034cd52;
     address public constant LDO = 0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32;
     address public constant FXS = 0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0;
+    address public constant WBTC = 0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599;
 
     // ctokens
     address public constant cDAI = 0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643;
@@ -63,4 +64,9 @@ library AddressBook {
     address public constant f156FRAX3CRV = 0x2ec70d3Ff3FD7ac5c2a72AAA64A398b6CA7428A5;
     address public constant f156cvxFXSFXSf = 0x30916E14C139d65CAfbEEcb3eA525c59df643281;
     address public constant f156CVX = 0x3F4a965Bff126af42FC014c20959c7b857EA4e35;
+
+    // ribbon
+    address public constant OPYN_ORACLE = 0x789cD7AB3742e23Ce0952F6Bc3Eb3A73A0E08833; // Opyn oracle
+    address public constant RSTETH_THETA = 0x53773E034d9784153471813dacAFF53dBBB78E8c; // rstETH-THETA (stETH Theta Vault)
+    address public constant RBTC_THETA = 0x65a833afDc250D9d38f8CD9bC2B1E3132dB13B2F; // rBTC-THETA (BTC Theta Vault)
 }


### PR DESCRIPTION
## Motivation

Have fixed income on [Ribbon Vaults](https://docs.ribbon.finance/).

## Solution

NOTE: THIS PROJECT IS TABLED UNTIL WE ASSIGN IT A HIGHER PRIORITY.
There has been slow progress on this. Below some relevant notes:

Ribbon vaults earn yield on its deposits by running a weekly automated covered call strategy/puts selling strategy. The vault reinvests the yield earned back into the strategy, effectively compounding the yields for depositors over time.
When user deposits some target, this deposit is deployed in the vault’s weekly strategy every Friday at 11am UTC. This means that if user makes a deposit on a Wednesday, those assets will remain "pending" until the cycle starts.

Withdrawals
Once user funds have been used in the vault’s weekly strategy they cannot be withdrawn until the vault closes its position the following Friday at 12pm UTC.
But, users can withdraw their funds instantly during the weekly timelock period where the vault closes its previous position and opens its new one.

Because of Ribbon's dynamics, `wrapUnderlying` and `unwrapTarget` would have to behave differently:

**wrapUnderlying**

For existing adapters at Sense, when wrapping underlying you immediately get target back. In this case, if I make a deposit of underlying on Ribbon, I won't get anything back (immediately) as the next cycle has not yet started. I can only claim the target back once the cycle started. So, we've decided to use a target wrapper so, when a deposit happens, we mint this wrapped target token and we can immediately return it back to the caller. 

**unwrapTarget**

For existing adapters at Sense, when unwrapping target you immediately get your underlying back. In this case, we can't withdraw from Ribbon at any time. This is a 2-step process:
- user initiates a withdrawal by calling [`initiateUnwrapTarget`](https://github.com/sense-finance/sense-v1/compare/dev...GEN-1151-ribbon-adapter#diff-aed4c8fb8fb7f504e715b7f7af7fc1e1e06ca332a7d2fd348310cb8e802ae4f0R172) and the adapter will call `initiateWithdraw` on Ribbon so as to inform them that we don't want to rollover our target to the next cycle. 
- once the cycle ends, we can complete withdrawal by calling `unwrapTarget` (which calls Ribbon's `completeWithdrawal`).

As this dynamic affects the behaviour `unwrapTarget` it will also affect any contract making use of these functions (e.g our Periphery).

Relevant to `initiateUnwrapTarget` there's this particular scenario:

- User A calls wrapUnderlying -> we mint wTarget at current pps (pricePerShare)
- ROUND CLOSES
- User B calls `wrapUnderlying` -> we mint wTarget at current pps
- User B calls `initiateUnwrapTarget` (without waiting for the round to be closed)
  - This call will make the adapter to initiate a withdraw and will make Ribbon not to rollover some target to the next cycle. This is not correct because User's B target is still pending (never got into an active cycle) so we should not be initiating a withdraw on the active deposits.
  - This is why we first need to [check](https://github.com/sense-finance/sense-v1/compare/dev...GEN-1151-ribbon-adapter#diff-aed4c8fb8fb7f504e715b7f7af7fc1e1e06ca332a7d2fd348310cb8e802ae4f0R197) if there's any pending target in Ribbon and we will make the adapter to call `withdrawInstant` which will return underlying and we could send this underlying back to the user (considering that the amount the underlying returned is enough to cover what the user is trying to withdraw. Otherwise, we would just initiate a normal withdraw **(*)**

**(*)** There's also un unresolved issue related to this explained a bit [here](https://github.com/sense-finance/sense-v1/compare/dev...GEN-1151-ribbon-adapter#diff-aed4c8fb8fb7f504e715b7f7af7fc1e1e06ca332a7d2fd348310cb8e802ae4f0R182). This is related to how to convert the wrapped target tokens the user is trying to unwrap to underlying.  

Note: there might still be other non-trivial, unexplored scenarios. 

## Implementer Checklist

<!--
Fill out the checklist below as applicable to your change. Bug fixes and new features must 
check off all of the required items.
-->


- [ ]  [FIRST TIME ONLY] Review the [Solcurity](https://github.com/Rari-Capital/solcurity) standard
- [ ]  [OPTIONAL] Create a reference implementation (in python or JS)
- [ ]  Create a short "Motivation" section for the PR
- [ ]  Write a spec for the feature and put it in the PR description – basic function names and expected state transitions is OK
- [ ]  Check all of the new revert paths with concrete tests
- [ ]  Check all of the new storage slot writes with concrete tests – do not make the passing test case the trivial case!
- [ ]  Go line-by-line through the new code and ensure it has all been covered by concrete tests – since we don’t have a coverage engine for foundry yet, you can imagine how one might check that each different code path is covered
- [ ]  Simplify the implementation and spend some time trying to minimize gas costs
- [ ]  Write fuzz tests for the feature – try everything to break the implementation (is this function monotonically in/decreasing, should it always be less than something else, etc)
- [ ]  Capture bugs discovered during the above steps in concrete tests (regression tests)
- [ ]  Add integration tests – fuzz or concrete tests that test how the new code affects the entire system, either locally or with a mainnet fork
- [ ]  [OPTIONAL] Integrate the feature into the deployment scripts
- [ ]  [OPTIONAL] Add new sanity checks to the deployment scripts
- [ ]  Get the PR reviewed by at least two people