### PR TITLE
GEN01334: fix _setGuard

### DIFF
--- a/pkg/core/src/adapters/abstract/factories/BaseFactory.sol
+++ b/pkg/core/src/adapters/abstract/factories/BaseFactory.sol
@@ -42,9 +42,6 @@ abstract contract BaseFactory {
     /// @notice Sense core Divider address
     address public immutable divider;
 
-    /// @notice target -> adapter
-    mapping(address => address) public adapters;
-
     /// @notice params for adapters deployed with this factory
     FactoryParams public factoryParams;
 

--- a/pkg/core/src/adapters/abstract/factories/BaseFactory.sol
+++ b/pkg/core/src/adapters/abstract/factories/BaseFactory.sol
@@ -101,9 +101,4 @@ abstract contract BaseFactory {
             } catch {}
         }
     }
-
-    /* ========== LOGS ========== */
-
-    /// @notice Logs the deployment of the adapter
-    event AdapterAdded(address addr, address indexed target);
 }

--- a/pkg/core/src/adapters/abstract/factories/CropFactory.sol
+++ b/pkg/core/src/adapters/abstract/factories/CropFactory.sol
@@ -20,7 +20,7 @@ abstract contract CropFactory is Trust, BaseFactory {
     /// @notice Update reward token for given adapter
     /// @param _adapter address of adapter to update the reward token on
     /// @param _rewardToken address of reward token
-    function setRewardTokens(address _adapter, address _rewardToken) public requiresTrust {
+    function setRewardToken(address _adapter, address _rewardToken) public requiresTrust {
         Crop(_adapter).setRewardToken(_rewardToken);
     }
 

--- a/pkg/core/src/adapters/abstract/factories/ERC4626CropsFactory.sol
+++ b/pkg/core/src/adapters/abstract/factories/ERC4626CropsFactory.sol
@@ -27,6 +27,7 @@ contract ERC4626CropsFactory is CropsFactory {
         address[] memory rewardTokens = abi.decode(data, (address[]));
 
         /// Sanity checks
+        if (Divider(divider).periphery() != msg.sender) revert Errors.OnlyPeriphery();
         if (!Divider(divider).permissionless() && !supportedTargets[_target]) revert Errors.TargetNotSupported();
 
         BaseAdapter.AdapterParams memory adapterParams = BaseAdapter.AdapterParams({
@@ -41,7 +42,7 @@ contract ERC4626CropsFactory is CropsFactory {
         });
 
         // Use the CREATE2 opcode to deploy a new Adapter contract.
-        // This will revert if a FAdapter with the provided target has already
+        // This will revert if am ERC4626 adapter with the provided target has already
         // been deployed, as the salt would be the same and we can't deploy with it twice.
         adapter = address(
             new ERC4626CropsAdapter{ salt: _target.fillLast12Bytes() }(

--- a/pkg/core/src/adapters/abstract/factories/ERC4626Factory.sol
+++ b/pkg/core/src/adapters/abstract/factories/ERC4626Factory.sol
@@ -28,6 +28,7 @@ contract ERC4626Factory is BaseFactory, Trust {
     /// @param data ABI encoded reward tokens address array
     function deployAdapter(address _target, bytes memory data) external override returns (address adapter) {
         /// Sanity checks
+        if (Divider(divider).periphery() != msg.sender) revert Errors.OnlyPeriphery();
         if (!Divider(divider).permissionless() && !supportedTargets[_target]) revert Errors.TargetNotSupported();
 
         BaseAdapter.AdapterParams memory adapterParams = BaseAdapter.AdapterParams({
@@ -42,7 +43,7 @@ contract ERC4626Factory is BaseFactory, Trust {
         });
 
         // Use the CREATE2 opcode to deploy a new Adapter contract.
-        // This will revert if a FAdapter with the provided target has already
+        // This will revert if an ERC4626 adapter with the provided target has already
         // been deployed, as the salt would be the same and we can't deploy with it twice.
         adapter = address(
             new ERC4626Adapter{ salt: _target.fillLast12Bytes() }(divider, _target, factoryParams.ifee, adapterParams)

--- a/pkg/core/src/adapters/implementations/compound/CFactory.sol
+++ b/pkg/core/src/adapters/implementations/compound/CFactory.sol
@@ -5,6 +5,7 @@ pragma solidity 0.8.11;
 import { CropFactory } from "../../abstract/factories/CropFactory.sol";
 import { CAdapter, ComptrollerLike } from "./CAdapter.sol";
 import { BaseAdapter } from "../../abstract/BaseAdapter.sol";
+import { Divider } from "../../../Divider.sol";
 
 // External references
 import { Bytes32AddressLib } from "@rari-capital/solmate/src/utils/Bytes32AddressLib.sol";
@@ -28,7 +29,10 @@ contract CFactory is CropFactory {
         address _reward
     ) CropFactory(_divider, _factoryParams, _reward) {}
 
-    function deployAdapter(address _target, bytes memory data) external override returns (address adapter) {
+    function deployAdapter(address _target, bytes memory) external override returns (address adapter) {
+        // Sanity check
+        if (Divider(divider).periphery() != msg.sender) revert Errors.OnlyPeriphery();
+
         (bool isListed, , ) = ComptrollerLike(COMPTROLLER).markets(_target);
         if (!isListed) revert Errors.TargetNotSupported();
 

--- a/pkg/core/src/adapters/implementations/fuse/FFactory.sol
+++ b/pkg/core/src/adapters/implementations/fuse/FFactory.sol
@@ -5,6 +5,7 @@ pragma solidity 0.8.11;
 import { CropsFactory } from "../../abstract/factories/CropsFactory.sol";
 import { FAdapter, FComptrollerLike, RewardsDistributorLike } from "./FAdapter.sol";
 import { BaseAdapter } from "../../abstract/BaseAdapter.sol";
+import { Divider } from "../../../Divider.sol";
 
 // External references
 import { Bytes32AddressLib } from "@rari-capital/solmate/src/utils/Bytes32AddressLib.sol";
@@ -32,6 +33,7 @@ contract FFactory is CropsFactory {
         address comptroller = abi.decode(data, (address));
 
         /// Sanity checks
+        if (Divider(divider).periphery() != msg.sender) revert Errors.OnlyPeriphery();
         if (!FusePoolLensLike(FUSE_POOL_DIRECTORY).poolExists(comptroller)) revert Errors.InvalidParam();
         (bool isListed, ) = FComptrollerLike(comptroller).markets(_target);
         if (!isListed) revert Errors.TargetNotSupported();

--- a/pkg/core/src/adapters/implementations/oracles/MasterPriceOracle.sol
+++ b/pkg/core/src/adapters/implementations/oracles/MasterPriceOracle.sol
@@ -11,8 +11,8 @@ import { IPriceFeed } from "../../abstract/IPriceFeed.sol";
 contract MasterPriceOracle is IPriceFeed, Trust {
     address public senseChainlinkPriceOracle;
 
-    /// @dev Maps underlying token addresses to `PriceOracle` contracts (can be `BasePriceOracle` contracts too).
-    mapping(address => address) public oracles; // TODO: use IPriceFeed.sol?
+    /// @dev Maps underlying token addresses to oracle addresses.
+    mapping(address => address) public oracles;
 
     /// @dev Constructor to initialize state variables.
     /// @param _chainlinkOracle The underlying ERC20 token addresses to link to `_oracles`.

--- a/pkg/core/src/tests/Periphery.t.sol
+++ b/pkg/core/src/tests/Periphery.t.sol
@@ -125,7 +125,8 @@ contract PeripheryTest is TestHelper {
         factory.supportTarget(address(newTarget), true);
 
         // onboard target
-        periphery.deployAdapter(address(factory), address(newTarget), "");
+        address[] memory rewardTokens;
+        periphery.deployAdapter(address(factory), address(newTarget), abi.encode(rewardTokens));
         address cTarget = ComptrollerLike(poolManager.comptroller()).cTokensByUnderlying(address(newTarget));
         assertTrue(cTarget != address(0));
     }
@@ -159,7 +160,8 @@ contract PeripheryTest is TestHelper {
         MockFactory(cropFactory).supportTarget(address(newTarget), true);
 
         // onboard target
-        periphery.deployAdapter(cropFactory, address(newTarget), "");
+        address[] memory rewardTokens;
+        periphery.deployAdapter(cropFactory, address(newTarget), abi.encode(rewardTokens));
         address cTarget = ComptrollerLike(poolManager.comptroller()).cTokensByUnderlying(address(newTarget));
         assertTrue(cTarget != address(0));
     }
@@ -172,7 +174,8 @@ contract PeripheryTest is TestHelper {
         factory.supportTarget(address(newTarget), true);
 
         // onboard target
-        periphery.deployAdapter(address(factory), address(newTarget), "");
+        address[] memory rewardTokens;
+        periphery.deployAdapter(address(factory), address(newTarget), abi.encode(rewardTokens));
         address cTarget = ComptrollerLike(poolManager.comptroller()).cTokensByUnderlying(address(newTarget));
         assertTrue(cTarget != address(0));
     }
@@ -186,17 +189,18 @@ contract PeripheryTest is TestHelper {
 
         // try deploying adapter using default factory
         hevm.expectRevert(abi.encodeWithSelector(Errors.TargetNotSupported.selector));
-        periphery.deployAdapter(address(factory), address(someTarget), "");
+        periphery.deployAdapter(address(factory), address(someTarget), abi.encode(rewardTokens));
 
         // try deploying adapter using new factory with supported target
-        periphery.deployAdapter(address(someFactory), address(someTarget), "");
+        periphery.deployAdapter(address(someFactory), address(someTarget), abi.encode(rewardTokens));
     }
 
     function testCantDeployAdapterIfTargetIsNotSupported() public {
+        address[] memory rewardTokens;
         MockToken someUnderlying = new MockToken("Some Underlying", "SU", 18);
         MockTargetLike newTarget = MockTargetLike(deployMockTarget(address(someUnderlying), "Some Target", "ST", 18));
         hevm.expectRevert(abi.encodeWithSelector(Errors.TargetNotSupported.selector));
-        periphery.deployAdapter(address(factory), address(newTarget), "");
+        periphery.deployAdapter(address(factory), address(newTarget), abi.encode(rewardTokens));
     }
 
     /* ========== admin update storage addresses ========== */
@@ -1236,7 +1240,8 @@ contract PeripheryTest is TestHelper {
 
         MockTargetLike otherTarget = MockTargetLike(deployMockTarget(address(underlying), "Compound Usdc", "cUSDC", 8));
         factory.supportTarget(address(otherTarget), true);
-        address dstAdapter = periphery.deployAdapter(address(factory), address(otherTarget), ""); // onboard target through Periphery
+        address[] memory rewardTokens;
+        address dstAdapter = periphery.deployAdapter(address(factory), address(otherTarget), abi.encode(rewardTokens)); // onboard target through Periphery
 
         (, , uint256 lpShares) = periphery.addLiquidityFromTarget(
             address(adapter),

--- a/pkg/core/src/tests/adapters/CropsAdapter.t.sol
+++ b/pkg/core/src/tests/adapters/CropsAdapter.t.sol
@@ -38,7 +38,7 @@ contract CropsAdapters is TestHelper {
 
         rewardTokens = [address(reward), address(reward2)];
         cropsFactory = MockCropsFactory(deployCropsFactory(address(aTarget), rewardTokens, true));
-        address f = periphery.deployAdapter(address(cropsFactory), address(aTarget), ""); // deploy & onboard target through Periphery
+        address f = periphery.deployAdapter(address(cropsFactory), address(aTarget), abi.encode(rewardTokens)); // deploy & onboard target through Periphery
         cropsAdapter = MockCropsAdapter(f);
         divider.setGuard(address(cropsAdapter), 10 * 2**128);
 

--- a/pkg/core/src/tests/factories/BaseFactory.t.sol
+++ b/pkg/core/src/tests/factories/BaseFactory.t.sol
@@ -13,6 +13,7 @@ import { BaseFactory } from "../../adapters/abstract/factories/BaseFactory.sol";
 import { FixedMath } from "../../external/FixedMath.sol";
 import { Errors } from "@sense-finance/v1-utils/src/libs/Errors.sol";
 import { Constants } from "../test-helpers/Constants.sol";
+import { Bytes32AddressLib } from "@rari-capital/solmate/src/utils/Bytes32AddressLib.sol";
 
 contract MockRevertAdapter is MockAdapter {
     constructor(BaseAdapter.AdapterParams memory _adapterParams)
@@ -30,6 +31,54 @@ contract MockRevertFactory is MockFactory {
     function deployAdapter(address _target, bytes memory data) external override returns (address adapter) {
         BaseAdapter.AdapterParams memory adapterParams;
         adapter = address(new MockRevertAdapter(adapterParams));
+        _setGuard(adapter);
+    }
+}
+
+// Mock adapter with 2e18 initial scale value
+contract Mock2e18Adapter is MockCropAdapter {
+    constructor(
+        address _divider,
+        address _target,
+        address _underlying,
+        uint128 _ifee,
+        AdapterParams memory _adapterParams,
+        address _reward
+    ) MockCropAdapter(_divider, _target, _underlying, _ifee, _adapterParams, _reward) {
+        INITIAL_VALUE = 2e18;
+    }
+}
+
+contract Mock2e18Factory is MockCropFactory {
+    using Bytes32AddressLib for address;
+
+    constructor(
+        address _divider,
+        FactoryParams memory _factoryParams,
+        address _reward
+    ) MockCropFactory(_divider, _factoryParams, _reward) {}
+
+    function deployAdapter(address _target, bytes memory data) external override returns (address adapter) {
+        BaseAdapter.AdapterParams memory adapterParams = BaseAdapter.AdapterParams({
+            oracle: factoryParams.oracle,
+            stake: factoryParams.stake,
+            stakeSize: factoryParams.stakeSize,
+            minm: factoryParams.minm,
+            maxm: factoryParams.maxm,
+            mode: factoryParams.mode,
+            tilt: factoryParams.tilt,
+            level: DEFAULT_LEVEL
+        });
+        adapter = address(
+            new Mock2e18Adapter{ salt: _target.fillLast12Bytes() }(
+                divider,
+                _target,
+                MockTargetLike(_target).underlying(),
+                factoryParams.ifee,
+                adapterParams,
+                reward
+            )
+        );
         _setGuard(adapter);
     }
 }
@@ -85,8 +134,34 @@ contract Factories is TestHelper {
 
         address[] memory rewardTokens = new address[](1);
         rewardTokens[0] = address(someReward);
-        MockCropFactory someFactory = MockCropFactory(deployCropsFactory(address(someTarget), rewardTokens, false));
 
+        // As we want to test guard calculation with a scale value different than 1e18 (which is the one used
+        // on the mock contracts), we use the Mock2e18Factory which uses deploys Mock2e18Adapter adapters.
+        // If we are testing with 4626, we can use the deployCropsFactory helper (we are not using
+        // mocks on this case). NOTE: trying to use hevm.mockCall to mock the scale call is not supported
+        // as we would be mocking the adapter with a pre-computed address and does not work.
+        MockCropFactory someFactory;
+        if (is4626) {
+            someFactory = MockCropFactory(deployCropsFactory(address(someTarget), rewardTokens, false));
+        } else {
+            BaseFactory.FactoryParams memory factoryParams = BaseFactory.FactoryParams({
+                stake: address(stake),
+                oracle: ORACLE,
+                ifee: ISSUANCE_FEE,
+                stakeSize: STAKE_SIZE,
+                minm: MIN_MATURITY,
+                maxm: MAX_MATURITY,
+                mode: MODE,
+                tilt: 0,
+                guard: DEFAULT_GUARD
+            });
+            someFactory = new Mock2e18Factory(address(divider), factoryParams, address(someReward));
+            someFactory.supportTarget(address(someTarget), true);
+            divider.setIsTrusted(address(someFactory), true);
+            periphery.setFactory(address(someFactory), true);
+        }
+
+        // deploy adapter via factory
         divider.setPeriphery(alice);
         MockCropAdapter adapter = MockCropAdapter(
             someFactory.deployAdapter(address(someTarget), abi.encode(rewardTokens))
@@ -110,8 +185,10 @@ contract Factories is TestHelper {
         } else {
             assertEq(adapter.reward(), address(someReward));
         }
+
+        // assert scale is 2e18 (or 1e18 if 4626)
         uint256 scale = adapter.scale();
-        assertEq(scale, 1e18);
+        assertEq(scale, is4626 ? 1e18 : 2e18);
 
         // Guard has been calculated with underlying-ETH (18 decimals),
         // target-underlying (18 decimals) and ETH-USD (8 decimals)
@@ -134,20 +211,24 @@ contract Factories is TestHelper {
         assertEq(guard, guardInTarget);
 
         // Sanity checks with constants values:
-        // as underlying price is 1e18, ETH price is 1900 (in 8 decimals) and scale is 1e18,
-        // (1) Underlying-USD price should be: 1e18 * (1900 * 1e8) -> normalised to 18 decimals = 1900 * 10**tDecimals
-        // (2) Target-USD price shuold be: 1e18 * (1900 * 1e18) -> normalised to 18 decimals decimals = 1900 * 10**tDecimals
+        // as underlying price is 1e18, ETH price is 1900 (in 8 decimals) and scale is 2e18,
+        // (1) Underlying-USD price should be: 1e18 * (1900 * 1e8) -> normalised to 18 decimals = 1900 * 1e18
+        // (2) Target-USD price should be: 2e18 * (1900 * 1e18) -> normalised to 18 decimals decimals = 3800 * 1e18
         // (3) and as the guard factory is $100'000 in 18 decimals
-        // then guard should be: (100000 * 1e18) / (1900 * 1e18) -> normalised to target decimals =
+        // then guard should be: (100000 * 1e18) / (3800 * 1e18) -> normalised to target decimals =
+        // * for 6 decimals target -> 26315789
+        // * for 8 decimals target -> 2631578947
+        // * for 18 decimals target -> 26315789473684210526
+        // NOTE: if 4626 tests, sacle value is 1e18 so values would be:
         // * for 6 decimals target -> 52631578
         // * for 8 decimals target -> 5263157894
         // * for 18 decimals target -> 52631578947368421052
         if (mockTargetDecimals == 6) {
-            assertEq(guard, 52631578);
+            assertEq(guard, is4626 ? 52631578 : 26315789);
         } else if (mockTargetDecimals == 8) {
-            assertEq(guard, 5263157894);
+            assertEq(guard, is4626 ? 5263157894 : 2631578947);
         } else if (mockTargetDecimals == 18) {
-            assertEq(guard, 52631578947368421052);
+            assertEq(guard, is4626 ? 52631578947368421052 : 26315789473684210526);
         }
     }
 

--- a/pkg/core/src/tests/factories/CFactory.tm.sol
+++ b/pkg/core/src/tests/factories/CFactory.tm.sol
@@ -131,7 +131,7 @@ contract CFactories is CAdapterTestHelper {
         // Convert DEFAULT_GUARD (which is $100'000 in 18 decimals) to target
         // using target's price (18 decimals)
         uint256 guardInTarget = DEFAULT_GUARD.fdiv(price, 10**tDecimals);
-        assertClose(guard, guardInTarget, guard.fmul(0.005e18));
+        assertClose(guard, guardInTarget, guard.fmul(0.010e18));
     }
 
     function testMainnetCantDeployAdapterIfNotSupportedTarget() public {

--- a/pkg/core/src/tests/factories/ERC4626Factory.tm.sol
+++ b/pkg/core/src/tests/factories/ERC4626Factory.tm.sol
@@ -12,6 +12,7 @@ import { BaseFactory } from "../../adapters/abstract/factories/BaseFactory.sol";
 import { Divider, TokenHandler } from "../../Divider.sol";
 import { Hevm } from "../test-helpers/Hevm.sol";
 import { FixedMath } from "../../external/FixedMath.sol";
+import { ERC20 } from "@rari-capital/solmate/src/tokens/ERC20.sol";
 
 import { DSTest } from "../test-helpers/test.sol";
 import { Hevm } from "../test-helpers/Hevm.sol";
@@ -139,9 +140,10 @@ contract ERC4626Factories is ERC4626TestHelper {
 
         // As we are testing with a stablecoin here (mUSD), we can think the scale
         // as the imUSD - USD rate, so we want to assert that the guard (which should be $100'000)
-        // in target terms is approx 100'000 / scale (within 10%).
+        // in target terms is approx 100'000 / scale (within 5%).
         (, , uint256 guard, ) = divider.adapterMeta(address(adapter));
-        assertClose(guard, (100000 * 1e36) / scale, guard.fmul(0.010e18));
+        uint256 tDecimals = ERC20(adapter.target()).decimals();
+        assertClose(guard, (DEFAULT_GUARD * 10**tDecimals) / scale, guard.fmul(0.005e18));
     }
 
     function testMainnetDeployCropsAdapter() public {

--- a/pkg/core/src/tests/factories/ERC4626Factory.tm.sol
+++ b/pkg/core/src/tests/factories/ERC4626Factory.tm.sol
@@ -196,7 +196,7 @@ contract ERC4626Factories is ERC4626TestHelper {
     function testMainnetCantDeployAdapterIfNotSupportedTarget() public {
         // Prepare data for adapter
         address[] memory rewardTokens;
-        bytes memory data = abi.encode(0, rewardTokens);
+        bytes memory data = abi.encode(rewardTokens);
 
         hevm.expectRevert(abi.encodeWithSelector(Errors.TargetNotSupported.selector));
         factory.deployAdapter(AddressBook.DAI, data);
@@ -211,7 +211,7 @@ contract ERC4626Factories is ERC4626TestHelper {
 
         // Prepare data for adapter
         address[] memory rewardTokens;
-        bytes memory data = abi.encode(0, rewardTokens);
+        bytes memory data = abi.encode(rewardTokens);
 
         factory.deployAdapter(AddressBook.IMUSD, data);
     }

--- a/pkg/core/src/tests/factories/ERC4626Factory.tm.sol
+++ b/pkg/core/src/tests/factories/ERC4626Factory.tm.sol
@@ -8,7 +8,7 @@ import { ERC4626Factory } from "../../adapters/abstract/factories/ERC4626Factory
 import { ERC4626CropsFactory } from "../../adapters/abstract/factories/ERC4626CropsFactory.sol";
 import { ChainlinkPriceOracle } from "../../adapters/implementations/oracles/ChainlinkPriceOracle.sol";
 import { MasterPriceOracle } from "../../adapters/implementations/oracles/MasterPriceOracle.sol";
-import { BaseFactory } from "../../adapters/abstract/factories/BaseFactory.sol";
+import { BaseFactory, ChainlinkOracleLike } from "../../adapters/abstract/factories/BaseFactory.sol";
 import { Divider, TokenHandler } from "../../Divider.sol";
 import { Hevm } from "../test-helpers/Hevm.sol";
 import { FixedMath } from "../../external/FixedMath.sol";
@@ -60,6 +60,7 @@ contract ERC4626TestHelper is DSTest {
         address[] memory oracles = new address[](1);
         oracles[0] = AddressBook.RARI_MSTABLE_ORACLE;
         masterOracle = new MasterPriceOracle(address(chainlinkOracle), underlyings, oracles);
+        assertEq(masterOracle.oracles(AddressBook.MUSD), AddressBook.RARI_MSTABLE_ORACLE);
 
         // deploy ERC4626 adapter factory
         BaseFactory.FactoryParams memory factoryParams = BaseFactory.FactoryParams({
@@ -138,12 +139,30 @@ contract ERC4626Factories is ERC4626TestHelper {
         uint256 scale = adapter.scale();
         assertTrue(scale > 0);
 
-        // As we are testing with a stablecoin here (mUSD), we can think the scale
-        // as the imUSD - USD rate, so we want to assert that the guard (which should be $100'000)
-        // in target terms is approx 100'000 / scale (within 5%).
+        // Guard has been calculated with underlying-ETH (18 decimals),
+        // target-underlying (18 decimals) and ETH-USD (8 decimals)
         (, , uint256 guard, ) = divider.adapterMeta(address(adapter));
         uint256 tDecimals = ERC20(adapter.target()).decimals();
-        assertClose(guard, (DEFAULT_GUARD * 10**tDecimals) / scale, guard.fmul(0.005e18));
+
+        // On this test we assert that the guard calculated is close to the one calculated below
+        // which uses Rari's mStable underlying-USD (8 decimals) and target-undelying (18 decimals)
+
+        // mUSD-ETH price (18 decimals)
+        uint256 underlyingPriceInEth = adapter.getUnderlyingPrice();
+
+        // ETH-USD price (8 decimals)
+        (, int256 ethPrice, , , ) = ChainlinkOracleLike(AddressBook.ETH_USD_PRICEFEED).latestRoundData();
+
+        // mUSD-USD price (18 decimals)
+        uint256 price = underlyingPriceInEth.fmul(uint256(ethPrice), 1e8);
+
+        // imUSD-USD price (normalised to target decimals)
+        price = scale.fmul(price, 10**tDecimals);
+
+        // Convert DEFAULT_GUARD (which is $100'000 in 18 decimals) to target
+        // using target's price (in target's decimals)
+        uint256 guardInTarget = DEFAULT_GUARD.fdiv(price, 10**tDecimals);
+        assertClose(guard, guardInTarget, guard.fmul(0.005e18));
     }
 
     function testMainnetDeployCropsAdapter() public {

--- a/pkg/core/src/tests/factories/ERC4626Factory.tm.sol
+++ b/pkg/core/src/tests/factories/ERC4626Factory.tm.sol
@@ -128,6 +128,7 @@ contract ERC4626Factories is ERC4626TestHelper {
 
     function testMainnetDeployAdapter() public {
         // Deploy non-crop adapter
+        hevm.prank(divider.periphery());
         ERC4626Adapter adapter = ERC4626Adapter(factory.deployAdapter(AddressBook.IMUSD, ""));
 
         assertTrue(address(adapter) != address(0));
@@ -162,7 +163,7 @@ contract ERC4626Factories is ERC4626TestHelper {
         // Convert DEFAULT_GUARD (which is $100'000 in 18 decimals) to target
         // using target's price (in target's decimals)
         uint256 guardInTarget = DEFAULT_GUARD.fdiv(price, 10**tDecimals);
-        assertClose(guard, guardInTarget, guard.fmul(0.005e18));
+        assertClose(guard, guardInTarget, guard.fmul(0.010e18));
     }
 
     function testMainnetDeployCropsAdapter() public {
@@ -173,6 +174,7 @@ contract ERC4626Factories is ERC4626TestHelper {
         bytes memory data = abi.encode(rewardTokens);
 
         // Deploy crops adapter
+        hevm.prank(divider.periphery());
         ERC4626CropsAdapter adapter = ERC4626CropsAdapter(cropsFactory.deployAdapter(AddressBook.IMUSD, data));
 
         assertTrue(address(adapter) != address(0));
@@ -198,6 +200,7 @@ contract ERC4626Factories is ERC4626TestHelper {
         address[] memory rewardTokens;
         bytes memory data = abi.encode(rewardTokens);
 
+        divider.setPeriphery(address(this));
         hevm.expectRevert(abi.encodeWithSelector(Errors.TargetNotSupported.selector));
         factory.deployAdapter(AddressBook.DAI, data);
     }
@@ -213,6 +216,7 @@ contract ERC4626Factories is ERC4626TestHelper {
         address[] memory rewardTokens;
         bytes memory data = abi.encode(rewardTokens);
 
+        hevm.prank(divider.periphery());
         factory.deployAdapter(AddressBook.IMUSD, data);
     }
 

--- a/pkg/core/src/tests/test-helpers/AddressBook.sol
+++ b/pkg/core/src/tests/test-helpers/AddressBook.sol
@@ -20,6 +20,7 @@ library AddressBook {
     address public constant cBAT = 0x6C8c6b02E7b2BE14d4fA6022Dfd6d75921D90E4E;
     address public constant cETH = 0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5;
     address public constant cUSDC = 0x39AA39c021dfbaE8faC545936693aC917d5E7563;
+    address public constant cLINK = 0xFAce851a4921ce59e912d19329929CE6da6EB0c7;
 
     // eth
     address public constant WSTETH = 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0;

--- a/pkg/core/src/tests/test-helpers/Constants.sol
+++ b/pkg/core/src/tests/test-helpers/Constants.sol
@@ -13,4 +13,5 @@ library Constants {
     uint16 public constant DEFAULT_MODE = 0;
     uint64 public constant DEFAULT_ISSUANCE_FEE = 0.05e18;
     uint256 public constant DEFAULT_GUARD = 100000 * 1e18;
+    uint256 public constant DEFAULT_CHAINLINK_ETH_PRICE = 1900 * 1e8; // $1900 per ETH
 }

--- a/pkg/core/src/tests/test-helpers/TestHelper.sol
+++ b/pkg/core/src/tests/test-helpers/TestHelper.sol
@@ -19,6 +19,7 @@ import { ERC4626CropsFactory } from "../../adapters/abstract/factories/ERC4626Cr
 import { MockFactory, MockCropFactory, MockCropsFactory, Mock4626CropsFactory } from "./mocks/MockFactory.sol";
 import { ERC20 } from "@rari-capital/solmate/src/tokens/ERC20.sol";
 import { AddressBook } from "./AddressBook.sol";
+import { Constants } from "./Constants.sol";
 
 // Space & Balanacer V2 mock
 import { MockSpaceFactory, MockBalancerVault } from "./mocks/MockSpace.sol";
@@ -223,9 +224,14 @@ contract TestHelper is DSTest {
             level: DEFAULT_LEVEL
         });
 
-        // mock all calls to Chainlink oracle
-        uint256 price = 1e8;
-        bytes memory returnData = abi.encode(1, int256(price), block.timestamp, block.timestamp, 1); // return data
+        // mock all calls to ETH_USD_PRICEFEED (Chainlink oracle)
+        bytes memory returnData = abi.encode(
+            1,
+            int256(Constants.DEFAULT_CHAINLINK_ETH_PRICE),
+            block.timestamp,
+            block.timestamp,
+            1
+        ); // return data
         ChainlinkOracleLike oracle = ChainlinkOracleLike(AddressBook.ETH_USD_PRICEFEED);
         hevm.mockCall(address(address(oracle)), abi.encodeWithSelector(oracle.latestRoundData.selector), returnData);
 

--- a/pkg/core/src/tests/test-helpers/mocks/MockFactory.sol
+++ b/pkg/core/src/tests/test-helpers/mocks/MockFactory.sol
@@ -80,7 +80,7 @@ contract MockCropFactory is CropFactory {
         targets[_target] = status;
     }
 
-    function deployAdapter(address _target, bytes memory data) external override returns (address adapter) {
+    function deployAdapter(address _target, bytes memory data) external virtual override returns (address adapter) {
         if (!targets[_target]) revert Errors.TargetNotSupported();
         if (Divider(divider).periphery() != msg.sender) revert Errors.OnlyPeriphery();
 
@@ -182,7 +182,7 @@ contract Mock4626CropFactory is CropFactory {
         targets[_target] = status;
     }
 
-    function deployAdapter(address _target, bytes memory data) external override returns (address adapter) {
+    function deployAdapter(address _target, bytes memory data) external virtual override returns (address adapter) {
         if (!targets[_target]) revert Errors.TargetNotSupported();
         if (Divider(divider).periphery() != msg.sender) revert Errors.OnlyPeriphery();
 


### PR DESCRIPTION
## Motivation

The new new changes in BaseFactory.sol introduced a bug which was causing the newly deployed adapters using a factory to set a really high cap because it was not considering the target's decimals. 

## Solution

Take target's decimals into account.

## Implementer Checklist

<!--
Fill out the checklist below as applicable to your change. Bug fixes and new features must 
check off all of the required items.
-->


- [ ]  [FIRST TIME ONLY] Review the [Solcurity](https://github.com/Rari-Capital/solcurity) standard
- [ ]  [OPTIONAL] Create a reference implementation (in python or JS)
- [x]  Create a short "Motivation" section for the PR
- [x]  Write a spec for the feature and put it in the PR description – basic function names and expected state transitions is OK
- [ ]  Check all of the new revert paths with concrete tests
- [ ]  Check all of the new storage slot writes with concrete tests – do not make the passing test case the trivial case!
- [ ]  Go line-by-line through the new code and ensure it has all been covered by concrete tests – since we don’t have a coverage engine for foundry yet, you can imagine how one might check that each different code path is covered
- [ ]  Simplify the implementation and spend some time trying to minimize gas costs
- [ ]  Write fuzz tests for the feature – try everything to break the implementation (is this function monotonically in/decreasing, should it always be less than something else, etc)
- [ ]  Capture bugs discovered during the above steps in concrete tests (regression tests)
- [ ]  Add integration tests – fuzz or concrete tests that test how the new code affects the entire system, either locally or with a mainnet fork
- [ ]  [OPTIONAL] Integrate the feature into the deployment scripts
- [ ]  [OPTIONAL] Add new sanity checks to the deployment scripts
- [ ]  Get the PR reviewed by at least two people