### PR TITLE
chore: add extractToken

### DIFF
--- a/pkg/core/src/adapters/abstract/BaseAdapter.sol
+++ b/pkg/core/src/adapters/abstract/BaseAdapter.sol
@@ -215,5 +215,5 @@ abstract contract BaseAdapter is Trust, IERC3156FlashLender {
     /* ========== LOGS ========== */
 
     event RewardsRecipientChanged(address indexed oldRecipient, address indexed newRecipient);
-    event RewardsClaimed(address indexed token, address indexed recipient);
+    event RewardsClaimed(address indexed token, address indexed recipient, uint256 indexed amount);
 }

--- a/pkg/core/src/adapters/abstract/BaseAdapter.sol
+++ b/pkg/core/src/adapters/abstract/BaseAdapter.sol
@@ -165,14 +165,16 @@ abstract contract BaseAdapter is Trust, IERC3156FlashLender {
         if (adapterParams.rType == 1) {
             if (token == Crop(address(this)).reward()) revert Errors.TokenNotSupported();
         } else if (adapterParams.rType == 2) {
-            bool keepGoing = true;
             uint256 i = 0;
             Crops adapter = Crops(address(this));
-            while (keepGoing) {
+            while (true) {
                 try adapter.rewardTokens(i) returns (address rewardToken) {
                     if (token == rewardToken) revert Errors.TokenNotSupported();
                 } catch {
-                    keepGoing = false;
+                    break;
+                }
+                unchecked {
+                    ++i;
                 }
             }
         }

--- a/pkg/core/src/adapters/abstract/BaseAdapter.sol
+++ b/pkg/core/src/adapters/abstract/BaseAdapter.sol
@@ -161,7 +161,7 @@ abstract contract BaseAdapter is Trust, IERC3156FlashLender {
 
     /// @notice Transfers reward tokens from the adapter to Sense's reward container
     /// @dev If adapter is either Crop or Crops, we check token is not any of the reward tokens
-    function extractToken(address token) external virtual {
+    function extractToken(address token) external {
         if (adapterParams.rType == 1) {
             if (token == Crop(address(this)).reward()) revert Errors.TokenNotSupported();
         } else if (adapterParams.rType == 2) {

--- a/pkg/core/src/adapters/abstract/BaseAdapter.sol
+++ b/pkg/core/src/adapters/abstract/BaseAdapter.sol
@@ -155,8 +155,8 @@ abstract contract BaseAdapter is Trust, IERC3156FlashLender {
     }
 
     function setRewardsRecipient(address recipient) external requiresTrust {
+        emit RewardsRecipientChanged(rewardsRecipient, recipient);
         rewardsRecipient = recipient;
-        emit RewardsRecipientChanged(rewardsRecipient);
     }
 
     /// @notice Transfers reward tokens from the adapter to Sense's reward container
@@ -243,6 +243,6 @@ abstract contract BaseAdapter is Trust, IERC3156FlashLender {
 
     /* ========== LOGS ========== */
 
-    event RewardsRecipientChanged(address indexed recipient);
+    event RewardsRecipientChanged(address indexed oldRecipient, address indexed newRecipient);
     event RewardsClaimed(address indexed token, address indexed recipient);
 }

--- a/pkg/core/src/adapters/abstract/erc4626/ERC4626Adapter.sol
+++ b/pkg/core/src/adapters/abstract/erc4626/ERC4626Adapter.sol
@@ -58,4 +58,12 @@ contract ERC4626Adapter is BaseAdapter {
     function unwrapTarget(uint256 shares) external override returns (uint256 _assets) {
         _assets = ERC4626(target).redeem(shares, msg.sender, msg.sender);
     }
+
+    function extractToken(address token) external virtual override {
+        // Check that token is neither the target nor the stake
+        if (token == target || token == adapterParams.stake) revert Errors.TokenNotSupported();
+        ERC20 t = ERC20(token);
+        t.safeTransfer(rewardsRecipient, t.balanceOf(address(this)));
+        emit RewardsClaimed(token, rewardsRecipient);
+    }
 }

--- a/pkg/core/src/adapters/abstract/erc4626/ERC4626Adapter.sol
+++ b/pkg/core/src/adapters/abstract/erc4626/ERC4626Adapter.sol
@@ -25,9 +25,10 @@ contract ERC4626Adapter is BaseAdapter {
     constructor(
         address _divider,
         address _target,
+        address _rewardsRecipient,
         uint128 _ifee,
         AdapterParams memory _adapterParams
-    ) BaseAdapter(_divider, _target, address(ERC4626(_target).asset()), _ifee, _adapterParams) {
+    ) BaseAdapter(_divider, _target, address(ERC4626(_target).asset()), _rewardsRecipient, _ifee, _adapterParams) {
         uint256 tDecimals = ERC4626(target).decimals();
         BASE_UINT = 10**tDecimals;
         SCALE_FACTOR = 10**(18 - tDecimals); // we assume targets decimals <= 18

--- a/pkg/core/src/adapters/abstract/erc4626/ERC4626Adapter.sol
+++ b/pkg/core/src/adapters/abstract/erc4626/ERC4626Adapter.sol
@@ -63,7 +63,8 @@ contract ERC4626Adapter is BaseAdapter {
         // Check that token is neither the target nor the stake
         if (token == target || token == adapterParams.stake) revert Errors.TokenNotSupported();
         ERC20 t = ERC20(token);
-        t.safeTransfer(rewardsRecipient, t.balanceOf(address(this)));
-        emit RewardsClaimed(token, rewardsRecipient);
+        uint256 tBal = t.balanceOf(address(this));
+        t.safeTransfer(rewardsRecipient, tBal);
+        emit RewardsClaimed(token, rewardsRecipient, tBal);
     }
 }

--- a/pkg/core/src/adapters/abstract/erc4626/ERC4626CropAdapter.sol
+++ b/pkg/core/src/adapters/abstract/erc4626/ERC4626CropAdapter.sol
@@ -33,7 +33,8 @@ contract ERC4626CropAdapter is ERC4626Adapter, Crop {
         // Check that token is neither the target, the stake nor the reward
         if (token == target || token == adapterParams.stake || token == reward) revert Errors.TokenNotSupported();
         ERC20 t = ERC20(token);
-        t.safeTransfer(rewardsRecipient, t.balanceOf(address(this)));
-        emit RewardsClaimed(token, rewardsRecipient);
+        uint256 tBal = t.balanceOf(address(this));
+        t.safeTransfer(rewardsRecipient, tBal);
+        emit RewardsClaimed(token, rewardsRecipient, tBal);
     }
 }

--- a/pkg/core/src/adapters/abstract/erc4626/ERC4626CropAdapter.sol
+++ b/pkg/core/src/adapters/abstract/erc4626/ERC4626CropAdapter.sol
@@ -10,10 +10,11 @@ contract ERC4626CropAdapter is ERC4626Adapter, Crop {
     constructor(
         address _divider,
         address _target,
+        address _rewardsRecipient,
         uint128 _ifee,
         AdapterParams memory _adapterParams,
         address _reward
-    ) ERC4626Adapter(_divider, _target, _ifee, _adapterParams) Crop(_divider, _reward) {}
+    ) ERC4626Adapter(_divider, _target, _rewardsRecipient, _ifee, _adapterParams) Crop(_divider, _reward) {}
 
     function notify(
         address _usr,

--- a/pkg/core/src/adapters/abstract/erc4626/ERC4626CropsAdapter.sol
+++ b/pkg/core/src/adapters/abstract/erc4626/ERC4626CropsAdapter.sol
@@ -10,10 +10,11 @@ contract ERC4626CropsAdapter is ERC4626Adapter, Crops {
     constructor(
         address _divider,
         address _target,
+        address _rewardsRecipient,
         uint128 _ifee,
         AdapterParams memory _adapterParams,
         address[] memory _rewardTokens
-    ) ERC4626Adapter(_divider, _target, _ifee, _adapterParams) Crops(_divider, _rewardTokens) {}
+    ) ERC4626Adapter(_divider, _target, _rewardsRecipient, _ifee, _adapterParams) Crops(_divider, _rewardTokens) {}
 
     function notify(
         address _usr,

--- a/pkg/core/src/adapters/abstract/erc4626/ERC4626CropsAdapter.sol
+++ b/pkg/core/src/adapters/abstract/erc4626/ERC4626CropsAdapter.sol
@@ -4,9 +4,14 @@ pragma solidity 0.8.11;
 import { ERC4626Adapter } from "./ERC4626Adapter.sol";
 import { BaseAdapter } from "../BaseAdapter.sol";
 import { Crops } from "../extensions/Crops.sol";
+import { Errors } from "@sense-finance/v1-utils/src/libs/Errors.sol";
+import { ERC20 } from "@rari-capital/solmate/src/tokens/ERC20.sol";
+import { SafeTransferLib } from "@rari-capital/solmate/src/utils/SafeTransferLib.sol";
 
 /// @notice Adapter contract for ERC4626 Vaults
 contract ERC4626CropsAdapter is ERC4626Adapter, Crops {
+    using SafeTransferLib for ERC20;
+
     constructor(
         address _divider,
         address _target,
@@ -22,5 +27,20 @@ contract ERC4626CropsAdapter is ERC4626Adapter, Crops {
         bool join
     ) public override(BaseAdapter, Crops) {
         super.notify(_usr, amt, join);
+    }
+
+    function extractToken(address token) external override {
+        for (uint256 i = 0; i < rewardTokens.length; ) {
+            if (token == rewardTokens[i]) revert Errors.TokenNotSupported();
+            unchecked {
+                ++i;
+            }
+        }
+
+        // Check that token is neither the target nor the stake
+        if (token == target || token == adapterParams.stake) revert Errors.TokenNotSupported();
+        ERC20 t = ERC20(token);
+        t.safeTransfer(rewardsRecipient, t.balanceOf(address(this)));
+        emit RewardsClaimed(token, rewardsRecipient);
     }
 }

--- a/pkg/core/src/adapters/abstract/erc4626/ERC4626CropsAdapter.sol
+++ b/pkg/core/src/adapters/abstract/erc4626/ERC4626CropsAdapter.sol
@@ -40,7 +40,8 @@ contract ERC4626CropsAdapter is ERC4626Adapter, Crops {
         // Check that token is neither the target nor the stake
         if (token == target || token == adapterParams.stake) revert Errors.TokenNotSupported();
         ERC20 t = ERC20(token);
-        t.safeTransfer(rewardsRecipient, t.balanceOf(address(this)));
-        emit RewardsClaimed(token, rewardsRecipient);
+        uint256 tBal = t.balanceOf(address(this));
+        t.safeTransfer(rewardsRecipient, tBal);
+        emit RewardsClaimed(token, rewardsRecipient, tBal);
     }
 }

--- a/pkg/core/src/adapters/abstract/extensions/Crop.sol
+++ b/pkg/core/src/adapters/abstract/extensions/Crop.sol
@@ -13,6 +13,7 @@ import { FixedMath } from "../../../external/FixedMath.sol";
 import { Trust } from "@sense-finance/v1-utils/src/Trust.sol";
 import { Errors } from "@sense-finance/v1-utils/src/libs/Errors.sol";
 
+/// @notice This is meant to be used with BaseAdapter.sol
 abstract contract Crop is Trust {
     using SafeTransferLib for ERC20;
     using FixedMath for uint256;
@@ -31,7 +32,6 @@ abstract contract Crop is Trust {
     event Distributed(address indexed usr, address indexed token, uint256 amount);
 
     constructor(address _divider, address _reward) {
-        setIsTrusted(msg.sender, true);
         setIsTrusted(_divider, true);
         reward = _reward;
     }

--- a/pkg/core/src/adapters/abstract/extensions/Crop.sol
+++ b/pkg/core/src/adapters/abstract/extensions/Crop.sol
@@ -30,7 +30,8 @@ abstract contract Crop is Trust {
 
     event Distributed(address indexed usr, address indexed token, uint256 amount);
 
-    constructor(address _divider, address _reward) Trust(msg.sender) {
+    constructor(address _divider, address _reward) {
+        setIsTrusted(msg.sender, true);
         setIsTrusted(_divider, true);
         reward = _reward;
     }

--- a/pkg/core/src/adapters/abstract/extensions/Crops.sol
+++ b/pkg/core/src/adapters/abstract/extensions/Crops.sol
@@ -13,6 +13,7 @@ import { FixedMath } from "../../../external/FixedMath.sol";
 import { Errors } from "@sense-finance/v1-utils/src/libs/Errors.sol";
 import { Trust } from "@sense-finance/v1-utils/src/Trust.sol";
 
+/// @notice This is meant to be used with BaseAdapter.sol
 abstract contract Crops is Trust {
     using SafeTransferLib for ERC20;
     using FixedMath for uint256;
@@ -37,7 +38,6 @@ abstract contract Crops is Trust {
     }
 
     constructor(address _divider, address[] memory _rewardTokens) {
-        setIsTrusted(msg.sender, true);
         setIsTrusted(_divider, true);
         rewardTokens = _rewardTokens;
     }

--- a/pkg/core/src/adapters/abstract/extensions/Crops.sol
+++ b/pkg/core/src/adapters/abstract/extensions/Crops.sol
@@ -36,7 +36,8 @@ abstract contract Crops is Trust {
         mapping(address => uint256) rewarded;
     }
 
-    constructor(address _divider, address[] memory _rewardTokens) Trust(msg.sender) {
+    constructor(address _divider, address[] memory _rewardTokens) {
+        setIsTrusted(msg.sender, true);
         setIsTrusted(_divider, true);
         rewardTokens = _rewardTokens;
     }

--- a/pkg/core/src/adapters/abstract/factories/BaseFactory.sol
+++ b/pkg/core/src/adapters/abstract/factories/BaseFactory.sol
@@ -58,7 +58,7 @@ abstract contract BaseFactory is Trust {
         uint256 minm; // min maturity (seconds after block.timstamp)
         uint256 maxm; // max maturity (seconds after block.timstamp)
         uint128 ifee; // issuance fee
-        uint8 mode; // 0 for monthly, 1 for weekly
+        uint16 mode; // 0 for monthly, 1 for weekly
         uint64 tilt; // tilt
         uint256 guard; // adapter guard (in usd, 18 decimals)
     }

--- a/pkg/core/src/adapters/abstract/factories/BaseFactory.sol
+++ b/pkg/core/src/adapters/abstract/factories/BaseFactory.sol
@@ -59,7 +59,6 @@ abstract contract BaseFactory is Trust {
         uint256 maxm; // max maturity (seconds after block.timstamp)
         uint128 ifee; // issuance fee
         uint8 mode; // 0 for monthly, 1 for weekly
-        uint8 rType; // 0 for non-crop, 1 for crop, 2 for crops
         uint64 tilt; // tilt
         uint256 guard; // adapter guard (in usd, 18 decimals)
     }
@@ -117,8 +116,8 @@ abstract contract BaseFactory is Trust {
     /// @dev existing adapters rewards recipients will not be changed and can be
     /// done through `setAdapterRewardsRecipient`
     function setRewardsRecipient(address _recipient) external requiresTrust {
+        emit RewardsRecipientChanged(rewardsRecipient, _recipient);
         rewardsRecipient = _recipient;
-        emit RewardsRecipientChanged(rewardsRecipient);
     }
 
     /// Set an adapter's rewards recipient
@@ -128,6 +127,5 @@ abstract contract BaseFactory is Trust {
 
     /* ========== LOGS ========== */
 
-    event AdminChanged(address indexed adapter);
-    event RewardsRecipientChanged(address indexed recipient);
+    event RewardsRecipientChanged(address indexed oldRecipient, address indexed newRecipient);
 }

--- a/pkg/core/src/adapters/abstract/factories/CropFactory.sol
+++ b/pkg/core/src/adapters/abstract/factories/CropFactory.sol
@@ -4,16 +4,16 @@ pragma solidity 0.8.11;
 // Internal references
 import { Crop } from "../extensions/Crop.sol";
 import { BaseFactory } from "./BaseFactory.sol";
-import { Trust } from "@sense-finance/v1-utils/src/Trust.sol";
 
-abstract contract CropFactory is Trust, BaseFactory {
+abstract contract CropFactory is BaseFactory {
     address public reward;
 
     constructor(
         address _divider,
+        address _rewardsRecipient,
         FactoryParams memory _factoryParams,
         address _reward
-    ) Trust(msg.sender) BaseFactory(_divider, _factoryParams) {
+    ) BaseFactory(_divider, _rewardsRecipient, _factoryParams) {
         reward = _reward;
     }
 

--- a/pkg/core/src/adapters/abstract/factories/CropsFactory.sol
+++ b/pkg/core/src/adapters/abstract/factories/CropsFactory.sol
@@ -6,11 +6,12 @@ import { Crops } from "../extensions/Crops.sol";
 import { BaseFactory } from "./BaseFactory.sol";
 import { Trust } from "@sense-finance/v1-utils/src/Trust.sol";
 
-abstract contract CropsFactory is Trust, BaseFactory {
-    constructor(address _divider, FactoryParams memory _factoryParams)
-        Trust(msg.sender)
-        BaseFactory(_divider, _factoryParams)
-    {}
+abstract contract CropsFactory is BaseFactory {
+    constructor(
+        address _divider,
+        address _rewardsRecipient,
+        FactoryParams memory _factoryParams
+    ) BaseFactory(_divider, _rewardsRecipient, _factoryParams) {}
 
     /// @notice Update reward tokens for given adapters
     /// @param _rewardTokens array of rewards tokens addresses

--- a/pkg/core/src/adapters/abstract/factories/ERC4626CropFactory.sol
+++ b/pkg/core/src/adapters/abstract/factories/ERC4626CropFactory.sol
@@ -18,9 +18,10 @@ contract ERC4626CropFactory is CropFactory {
 
     constructor(
         address _divider,
+        address _rewardsRecipient,
         FactoryParams memory _factoryParams,
         address _reward
-    ) CropFactory(_divider, _factoryParams, address(0)) {}
+    ) CropFactory(_divider, _rewardsRecipient, _factoryParams, address(0)) {}
 
     /// @notice Deploys an ERC4626Adapter contract
     /// @param _target The target address
@@ -39,6 +40,7 @@ contract ERC4626CropFactory is CropFactory {
             minm: factoryParams.minm,
             maxm: factoryParams.maxm,
             mode: factoryParams.mode,
+            rType: factoryParams.rType,
             tilt: factoryParams.tilt,
             level: DEFAULT_LEVEL
         });
@@ -50,6 +52,7 @@ contract ERC4626CropFactory is CropFactory {
             new ERC4626CropAdapter{ salt: _target.fillLast12Bytes() }(
                 divider,
                 _target,
+                rewardsRecipient,
                 factoryParams.ifee,
                 adapterParams,
                 reward

--- a/pkg/core/src/adapters/abstract/factories/ERC4626CropFactory.sol
+++ b/pkg/core/src/adapters/abstract/factories/ERC4626CropFactory.sol
@@ -40,7 +40,7 @@ contract ERC4626CropFactory is CropFactory {
             minm: factoryParams.minm,
             maxm: factoryParams.maxm,
             mode: factoryParams.mode,
-            rType: factoryParams.rType,
+            rType: 1, // Crop
             tilt: factoryParams.tilt,
             level: DEFAULT_LEVEL
         });

--- a/pkg/core/src/adapters/abstract/factories/ERC4626CropFactory.sol
+++ b/pkg/core/src/adapters/abstract/factories/ERC4626CropFactory.sol
@@ -40,7 +40,6 @@ contract ERC4626CropFactory is CropFactory {
             minm: factoryParams.minm,
             maxm: factoryParams.maxm,
             mode: factoryParams.mode,
-            rType: 1, // Crop
             tilt: factoryParams.tilt,
             level: DEFAULT_LEVEL
         });

--- a/pkg/core/src/adapters/abstract/factories/ERC4626CropsFactory.sol
+++ b/pkg/core/src/adapters/abstract/factories/ERC4626CropsFactory.sol
@@ -16,7 +16,11 @@ contract ERC4626CropsFactory is CropsFactory {
 
     mapping(address => bool) public supportedTargets;
 
-    constructor(address _divider, FactoryParams memory _factoryParams) CropsFactory(_divider, _factoryParams) {}
+    constructor(
+        address _divider,
+        address _rewardsRecipient,
+        FactoryParams memory _factoryParams
+    ) CropsFactory(_divider, _rewardsRecipient, _factoryParams) {}
 
     /// @notice Deploys an ERC4626Adapter contract
     /// @param _target The target address
@@ -35,6 +39,7 @@ contract ERC4626CropsFactory is CropsFactory {
             minm: factoryParams.minm,
             maxm: factoryParams.maxm,
             mode: factoryParams.mode,
+            rType: factoryParams.rType,
             tilt: factoryParams.tilt,
             level: DEFAULT_LEVEL
         });
@@ -46,6 +51,7 @@ contract ERC4626CropsFactory is CropsFactory {
             new ERC4626CropsAdapter{ salt: _target.fillLast12Bytes() }(
                 divider,
                 _target,
+                rewardsRecipient,
                 factoryParams.ifee,
                 adapterParams,
                 rewardTokens

--- a/pkg/core/src/adapters/abstract/factories/ERC4626CropsFactory.sol
+++ b/pkg/core/src/adapters/abstract/factories/ERC4626CropsFactory.sol
@@ -39,7 +39,6 @@ contract ERC4626CropsFactory is CropsFactory {
             minm: factoryParams.minm,
             maxm: factoryParams.maxm,
             mode: factoryParams.mode,
-            rType: 2, // Crops
             tilt: factoryParams.tilt,
             level: DEFAULT_LEVEL
         });

--- a/pkg/core/src/adapters/abstract/factories/ERC4626CropsFactory.sol
+++ b/pkg/core/src/adapters/abstract/factories/ERC4626CropsFactory.sol
@@ -39,7 +39,7 @@ contract ERC4626CropsFactory is CropsFactory {
             minm: factoryParams.minm,
             maxm: factoryParams.maxm,
             mode: factoryParams.mode,
-            rType: factoryParams.rType,
+            rType: 2, // Crops
             tilt: factoryParams.tilt,
             level: DEFAULT_LEVEL
         });

--- a/pkg/core/src/adapters/abstract/factories/ERC4626Factory.sol
+++ b/pkg/core/src/adapters/abstract/factories/ERC4626Factory.sol
@@ -7,20 +7,20 @@ import { ERC4626Adapter } from "../erc4626/ERC4626Adapter.sol";
 import { BaseAdapter } from "../../abstract/BaseAdapter.sol";
 import { BaseFactory } from "./BaseFactory.sol";
 import { Errors } from "@sense-finance/v1-utils/src/libs/Errors.sol";
-import { Trust } from "@sense-finance/v1-utils/src/Trust.sol";
 
 // External references
 import { Bytes32AddressLib } from "@rari-capital/solmate/src/utils/Bytes32AddressLib.sol";
 
-contract ERC4626Factory is BaseFactory, Trust {
+contract ERC4626Factory is BaseFactory {
     using Bytes32AddressLib for address;
 
     mapping(address => bool) public supportedTargets;
 
-    constructor(address _divider, FactoryParams memory _factoryParams)
-        BaseFactory(_divider, _factoryParams)
-        Trust(msg.sender)
-    {}
+    constructor(
+        address _divider,
+        address _rewardsRecipient,
+        FactoryParams memory _factoryParams
+    ) BaseFactory(_divider, _rewardsRecipient, _factoryParams) {}
 
     /// @notice Deploys an ERC4626Adapter contract
     /// @param _target The target address
@@ -37,6 +37,7 @@ contract ERC4626Factory is BaseFactory, Trust {
             minm: factoryParams.minm,
             maxm: factoryParams.maxm,
             mode: factoryParams.mode,
+            rType: factoryParams.rType,
             tilt: factoryParams.tilt,
             level: DEFAULT_LEVEL
         });
@@ -45,7 +46,13 @@ contract ERC4626Factory is BaseFactory, Trust {
         // This will revert if an ERC4626 adapter with the provided target has already
         // been deployed, as the salt would be the same and we can't deploy with it twice.
         adapter = address(
-            new ERC4626Adapter{ salt: _target.fillLast12Bytes() }(divider, _target, factoryParams.ifee, adapterParams)
+            new ERC4626Adapter{ salt: _target.fillLast12Bytes() }(
+                divider,
+                _target,
+                rewardsRecipient,
+                factoryParams.ifee,
+                adapterParams
+            )
         );
 
         _setGuard(adapter);

--- a/pkg/core/src/adapters/abstract/factories/ERC4626Factory.sol
+++ b/pkg/core/src/adapters/abstract/factories/ERC4626Factory.sol
@@ -37,7 +37,7 @@ contract ERC4626Factory is BaseFactory {
             minm: factoryParams.minm,
             maxm: factoryParams.maxm,
             mode: factoryParams.mode,
-            rType: factoryParams.rType,
+            rType: 0, // Non-crop
             tilt: factoryParams.tilt,
             level: DEFAULT_LEVEL
         });

--- a/pkg/core/src/adapters/abstract/factories/ERC4626Factory.sol
+++ b/pkg/core/src/adapters/abstract/factories/ERC4626Factory.sol
@@ -37,7 +37,6 @@ contract ERC4626Factory is BaseFactory {
             minm: factoryParams.minm,
             maxm: factoryParams.maxm,
             mode: factoryParams.mode,
-            rType: 0, // Non-crop
             tilt: factoryParams.tilt,
             level: DEFAULT_LEVEL
         });

--- a/pkg/core/src/adapters/implementations/compound/CAdapter.sol
+++ b/pkg/core/src/adapters/implementations/compound/CAdapter.sol
@@ -184,8 +184,9 @@ contract CAdapter is BaseAdapter, Crop {
         // Check that token is neither the target, the stake nor the reward
         if (token == target || token == adapterParams.stake || token == reward) revert Errors.TokenNotSupported();
         ERC20 t = ERC20(token);
-        t.safeTransfer(rewardsRecipient, t.balanceOf(address(this)));
-        emit RewardsClaimed(token, rewardsRecipient);
+        uint256 tBal = t.balanceOf(address(this));
+        t.safeTransfer(rewardsRecipient, tBal);
+        emit RewardsClaimed(token, rewardsRecipient, tBal);
     }
 
     function _to18Decimals(uint256 exRate) internal view returns (uint256) {

--- a/pkg/core/src/adapters/implementations/compound/CAdapter.sol
+++ b/pkg/core/src/adapters/implementations/compound/CAdapter.sol
@@ -180,6 +180,14 @@ contract CAdapter is BaseAdapter, Crop {
         ERC20(underlying).safeTransfer(msg.sender, uBal);
     }
 
+    function extractToken(address token) external override {
+        // Check that token is neither the target, the stake nor the reward
+        if (token == target || token == adapterParams.stake || token == reward) revert Errors.TokenNotSupported();
+        ERC20 t = ERC20(token);
+        t.safeTransfer(rewardsRecipient, t.balanceOf(address(this)));
+        emit RewardsClaimed(token, rewardsRecipient);
+    }
+
     function _to18Decimals(uint256 exRate) internal view returns (uint256) {
         // From the Compound docs:
         // "exchangeRateCurrent() returns the exchange rate, scaled by 1 * 10^(18 - 8 + Underlying Token Decimals)"

--- a/pkg/core/src/adapters/implementations/compound/CAdapter.sol
+++ b/pkg/core/src/adapters/implementations/compound/CAdapter.sol
@@ -96,10 +96,11 @@ contract CAdapter is BaseAdapter, Crop {
         address _divider,
         address _target,
         address _underlying,
+        address _rewardsRecipient,
         uint128 _ifee,
         AdapterParams memory _adapterParams,
         address _reward
-    ) Crop(_divider, _reward) BaseAdapter(_divider, _target, _underlying, _ifee, _adapterParams) {
+    ) Crop(_divider, _reward) BaseAdapter(_divider, _target, _underlying, _rewardsRecipient, _ifee, _adapterParams) {
         isCETH = _target == CETH;
         ERC20(_underlying).safeApprove(_target, type(uint256).max);
         uDecimals = CTokenLike(_underlying).decimals();

--- a/pkg/core/src/adapters/implementations/compound/CFactory.sol
+++ b/pkg/core/src/adapters/implementations/compound/CFactory.sol
@@ -47,7 +47,7 @@ contract CFactory is CropFactory {
             minm: factoryParams.minm,
             maxm: factoryParams.maxm,
             mode: factoryParams.mode,
-            rType: factoryParams.rType,
+            rType: 1, // Crop
             tilt: factoryParams.tilt,
             level: DEFAULT_LEVEL
         });

--- a/pkg/core/src/adapters/implementations/compound/CFactory.sol
+++ b/pkg/core/src/adapters/implementations/compound/CFactory.sol
@@ -47,7 +47,6 @@ contract CFactory is CropFactory {
             minm: factoryParams.minm,
             maxm: factoryParams.maxm,
             mode: factoryParams.mode,
-            rType: 1, // Crop
             tilt: factoryParams.tilt,
             level: DEFAULT_LEVEL
         });

--- a/pkg/core/src/adapters/implementations/compound/CFactory.sol
+++ b/pkg/core/src/adapters/implementations/compound/CFactory.sol
@@ -25,9 +25,10 @@ contract CFactory is CropFactory {
 
     constructor(
         address _divider,
+        address _rewardsRecipient,
         FactoryParams memory _factoryParams,
         address _reward
-    ) CropFactory(_divider, _factoryParams, _reward) {}
+    ) CropFactory(_divider, _rewardsRecipient, _factoryParams, _reward) {}
 
     function deployAdapter(address _target, bytes memory) external override returns (address adapter) {
         // Sanity check
@@ -46,6 +47,7 @@ contract CFactory is CropFactory {
             minm: factoryParams.minm,
             maxm: factoryParams.maxm,
             mode: factoryParams.mode,
+            rType: factoryParams.rType,
             tilt: factoryParams.tilt,
             level: DEFAULT_LEVEL
         });
@@ -54,6 +56,7 @@ contract CFactory is CropFactory {
                 divider,
                 _target,
                 _target == CETH ? WETH : CTokenLike(_target).underlying(),
+                rewardsRecipient,
                 factoryParams.ifee,
                 adapterParams,
                 reward

--- a/pkg/core/src/adapters/implementations/fuse/FAdapter.sol
+++ b/pkg/core/src/adapters/implementations/fuse/FAdapter.sol
@@ -75,12 +75,16 @@ contract FAdapter is BaseAdapter, Crops {
         address _divider,
         address _target,
         address _underlying,
+        address _rewardsRecipient,
         uint128 _ifee,
         address _comptroller,
         AdapterParams memory _adapterParams,
         address[] memory _rewardTokens,
         address[] memory _rewardsDistributorsList
-    ) Crops(_divider, _rewardTokens) BaseAdapter(_divider, _target, _underlying, _ifee, _adapterParams) {
+    )
+        Crops(_divider, _rewardTokens)
+        BaseAdapter(_divider, _target, _underlying, _rewardsRecipient, _ifee, _adapterParams)
+    {
         rewardTokens = _rewardTokens;
         comptroller = _comptroller;
         isFETH = FTokenLike(_target).isCEther();

--- a/pkg/core/src/adapters/implementations/fuse/FAdapter.sol
+++ b/pkg/core/src/adapters/implementations/fuse/FAdapter.sol
@@ -183,8 +183,9 @@ contract FAdapter is BaseAdapter, Crops {
         // Check that token is neither the target nor the stake
         if (token == target || token == adapterParams.stake) revert Errors.TokenNotSupported();
         ERC20 t = ERC20(token);
-        t.safeTransfer(rewardsRecipient, t.balanceOf(address(this)));
-        emit RewardsClaimed(token, rewardsRecipient);
+        uint256 tBal = t.balanceOf(address(this));
+        t.safeTransfer(rewardsRecipient, tBal);
+        emit RewardsClaimed(token, rewardsRecipient, tBal);
     }
 
     /* ========== ADMIN ========== */

--- a/pkg/core/src/adapters/implementations/fuse/FFactory.sol
+++ b/pkg/core/src/adapters/implementations/fuse/FFactory.sol
@@ -65,7 +65,7 @@ contract FFactory is CropsFactory {
             minm: factoryParams.minm,
             maxm: factoryParams.maxm,
             mode: factoryParams.mode,
-            rType: factoryParams.rType,
+            rType: 2, // Crops
             tilt: factoryParams.tilt,
             level: DEFAULT_LEVEL
         });

--- a/pkg/core/src/adapters/implementations/fuse/FFactory.sol
+++ b/pkg/core/src/adapters/implementations/fuse/FFactory.sol
@@ -27,7 +27,11 @@ contract FFactory is CropsFactory {
     address public constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
     address public constant FUSE_POOL_DIRECTORY = 0x835482FE0532f169024d5E9410199369aAD5C77E;
 
-    constructor(address _divider, FactoryParams memory _factoryParams) CropsFactory(_divider, _factoryParams) {}
+    constructor(
+        address _divider,
+        address _rewardsRecipient,
+        FactoryParams memory _factoryParams
+    ) CropsFactory(_divider, _rewardsRecipient, _factoryParams) {}
 
     function deployAdapter(address _target, bytes memory data) external override returns (address adapter) {
         address comptroller = abi.decode(data, (address));
@@ -61,6 +65,7 @@ contract FFactory is CropsFactory {
             minm: factoryParams.minm,
             maxm: factoryParams.maxm,
             mode: factoryParams.mode,
+            rType: factoryParams.rType,
             tilt: factoryParams.tilt,
             level: DEFAULT_LEVEL
         });
@@ -72,6 +77,7 @@ contract FFactory is CropsFactory {
                 divider,
                 _target,
                 FTokenLike(_target).isCEther() ? WETH : underlying,
+                rewardsRecipient,
                 factoryParams.ifee,
                 comptroller,
                 adapterParams,

--- a/pkg/core/src/adapters/implementations/fuse/FFactory.sol
+++ b/pkg/core/src/adapters/implementations/fuse/FFactory.sol
@@ -65,7 +65,6 @@ contract FFactory is CropsFactory {
             minm: factoryParams.minm,
             maxm: factoryParams.maxm,
             mode: factoryParams.mode,
-            rType: 2, // Crops
             tilt: factoryParams.tilt,
             level: DEFAULT_LEVEL
         });

--- a/pkg/core/src/adapters/implementations/lido/WstETHAdapter.sol
+++ b/pkg/core/src/adapters/implementations/lido/WstETHAdapter.sol
@@ -98,7 +98,8 @@ contract WstETHAdapter is BaseAdapter {
         // Check that token is neither the target nor the stake
         if (token == target || token == adapterParams.stake) revert Errors.TokenNotSupported();
         ERC20 t = ERC20(token);
-        t.safeTransfer(rewardsRecipient, t.balanceOf(address(this)));
-        emit RewardsClaimed(token, rewardsRecipient);
+        uint256 tBal = t.balanceOf(address(this));
+        t.safeTransfer(rewardsRecipient, tBal);
+        emit RewardsClaimed(token, rewardsRecipient, tBal);
     }
 }

--- a/pkg/core/src/adapters/implementations/lido/WstETHAdapter.sol
+++ b/pkg/core/src/adapters/implementations/lido/WstETHAdapter.sol
@@ -52,9 +52,10 @@ contract WstETHAdapter is BaseAdapter {
     constructor(
         address _divider,
         address _target,
+        address _rewardsRecipient,
         uint128 _ifee,
         BaseAdapter.AdapterParams memory _adapterParams
-    ) BaseAdapter(_divider, _target, STETH, _ifee, _adapterParams) {
+    ) BaseAdapter(_divider, _target, STETH, _rewardsRecipient, _ifee, _adapterParams) {
         // approve wstETH contract to pull stETH (used on wrapUnderlying())
         ERC20(STETH).approve(WSTETH, type(uint256).max);
         // set an inital cached scale value

--- a/pkg/core/src/adapters/implementations/lido/WstETHAdapter.sol
+++ b/pkg/core/src/adapters/implementations/lido/WstETHAdapter.sol
@@ -93,4 +93,12 @@ contract WstETHAdapter is BaseAdapter {
         // wrap stETH into wstETH and transfer it back to sender
         ERC20(WSTETH).safeTransfer(msg.sender, wstETH = WstETHLike(WSTETH).wrap(amount));
     }
+
+    function extractToken(address token) external override {
+        // Check that token is neither the target nor the stake
+        if (token == target || token == adapterParams.stake) revert Errors.TokenNotSupported();
+        ERC20 t = ERC20(token);
+        t.safeTransfer(rewardsRecipient, t.balanceOf(address(this)));
+        emit RewardsClaimed(token, rewardsRecipient);
+    }
 }

--- a/pkg/core/src/tests/Divider.t.sol
+++ b/pkg/core/src/tests/Divider.t.sol
@@ -10,6 +10,7 @@ import { Errors } from "@sense-finance/v1-utils/src/libs/Errors.sol";
 
 import { Levels } from "@sense-finance/v1-utils/src/libs/Levels.sol";
 import { TestHelper } from "./test-helpers/TestHelper.sol";
+import { Constants } from "./test-helpers/Constants.sol";
 import { MockAdapter, MockCropAdapter, MockBaseAdapter } from "./test-helpers/mocks/MockAdapter.sol";
 import { BaseAdapter } from "../adapters/abstract/BaseAdapter.sol";
 import { Divider } from "../Divider.sol";
@@ -331,9 +332,11 @@ contract Dividers is TestHelper {
 
     function testSettleSeriesWithMockBaseAdapter() public {
         divider.setPermissionless(true);
+        DEFAULT_ADAPTER_PARAMS.rType = Constants.NON_CROP;
         MockBaseAdapter aAdapter = new MockBaseAdapter(
             address(divider),
             address(target),
+            Constants.REWARDS_RECIPIENT,
             !is4626Target ? target.underlying() : target.asset(),
             ISSUANCE_FEE,
             DEFAULT_ADAPTER_PARAMS

--- a/pkg/core/src/tests/Divider.t.sol
+++ b/pkg/core/src/tests/Divider.t.sol
@@ -332,7 +332,6 @@ contract Dividers is TestHelper {
 
     function testSettleSeriesWithMockBaseAdapter() public {
         divider.setPermissionless(true);
-        DEFAULT_ADAPTER_PARAMS.rType = Constants.NON_CROP;
         MockBaseAdapter aAdapter = new MockBaseAdapter(
             address(divider),
             address(target),

--- a/pkg/core/src/tests/Periphery.t.sol
+++ b/pkg/core/src/tests/Periphery.t.sol
@@ -18,6 +18,7 @@ import { ERC20 } from "@rari-capital/solmate/src/tokens/ERC20.sol";
 import { Errors } from "@sense-finance/v1-utils/src/libs/Errors.sol";
 import { BalancerPool } from "../external/balancer/Pool.sol";
 import { BalancerVault } from "../external/balancer/Vault.sol";
+import { Constants } from "./test-helpers/Constants.sol";
 
 contract PeripheryTest is TestHelper {
     using FixedMath for uint256;
@@ -60,6 +61,7 @@ contract PeripheryTest is TestHelper {
             address(divider),
             address(target),
             !is4626Target ? target.underlying() : target.asset(),
+            Constants.REWARDS_RECIPIENT,
             ISSUANCE_FEE,
             DEFAULT_ADAPTER_PARAMS,
             address(reward)
@@ -92,6 +94,7 @@ contract PeripheryTest is TestHelper {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: 0,
+            rType: Constants.CROP,
             tilt: 0,
             level: DEFAULT_LEVEL
         });
@@ -99,6 +102,7 @@ contract PeripheryTest is TestHelper {
             address(divider),
             address(target),
             !is4626Target ? target.underlying() : target.asset(),
+            Constants.REWARDS_RECIPIENT,
             ISSUANCE_FEE,
             adapterParams,
             address(reward)
@@ -176,15 +180,20 @@ contract PeripheryTest is TestHelper {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
+            rType: Constants.CROP,
             tilt: 0,
             guard: DEFAULT_GUARD
         });
 
         address cropFactory;
         if (is4626Target) {
-            cropFactory = address(new Mock4626CropFactory(address(divider), factoryParams, address(reward)));
+            cropFactory = address(
+                new Mock4626CropFactory(address(divider), Constants.REWARDS_RECIPIENT, factoryParams, address(reward))
+            );
         } else {
-            cropFactory = address(new MockCropFactory(address(divider), factoryParams, address(reward)));
+            cropFactory = address(
+                new MockCropFactory(address(divider), Constants.REWARDS_RECIPIENT, factoryParams, address(reward))
+            );
         }
         divider.setIsTrusted(cropFactory, true);
         periphery.setFactory(cropFactory, true);
@@ -1117,6 +1126,7 @@ contract PeripheryTest is TestHelper {
         divider.setPermissionless(true);
         uint16 level = 0x1 + 0x2 + 0x4 + 0x8; // redeem restricted
         DEFAULT_ADAPTER_PARAMS.level = level;
+        DEFAULT_ADAPTER_PARAMS.rType = Constants.NON_CROP;
         MockAdapter aAdapter = MockAdapter(deployMockAdapter(address(divider), address(target), address(reward)));
 
         periphery.verifyAdapter(address(aAdapter), true);

--- a/pkg/core/src/tests/Periphery.t.sol
+++ b/pkg/core/src/tests/Periphery.t.sol
@@ -180,7 +180,6 @@ contract PeripheryTest is TestHelper {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
-            rType: Constants.CROP,
             tilt: 0,
             guard: DEFAULT_GUARD
         });

--- a/pkg/core/src/tests/Periphery.t.sol
+++ b/pkg/core/src/tests/Periphery.t.sol
@@ -94,7 +94,6 @@ contract PeripheryTest is TestHelper {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: 0,
-            rType: Constants.CROP,
             tilt: 0,
             level: DEFAULT_LEVEL
         });
@@ -1125,7 +1124,6 @@ contract PeripheryTest is TestHelper {
         divider.setPermissionless(true);
         uint16 level = 0x1 + 0x2 + 0x4 + 0x8; // redeem restricted
         DEFAULT_ADAPTER_PARAMS.level = level;
-        DEFAULT_ADAPTER_PARAMS.rType = Constants.NON_CROP;
         MockAdapter aAdapter = MockAdapter(deployMockAdapter(address(divider), address(target), address(reward)));
 
         periphery.verifyAdapter(address(aAdapter), true);

--- a/pkg/core/src/tests/Periphery.tm.sol
+++ b/pkg/core/src/tests/Periphery.tm.sol
@@ -93,6 +93,7 @@ contract PeripheryTestHelper is DSTest, LiquidityHelper {
             minm: 0, // 0 minm, so there's not lower bound on future maturity
             maxm: type(uint64).max, // large maxm, so there's not upper bound on future maturity
             mode: 0, // monthly maturities
+            rType: Constants.CROP, // reward type
             tilt: 0,
             level: Constants.DEFAULT_LEVEL
         });
@@ -100,6 +101,7 @@ contract PeripheryTestHelper is DSTest, LiquidityHelper {
             address(divider),
             address(mockTarget),
             mockTarget.underlying(),
+            Constants.REWARDS_RECIPIENT,
             IFEE_FOR_YT_SWAPS,
             mockAdapterParams,
             address(new MockToken("Reward", "R", 18))
@@ -115,12 +117,15 @@ contract PeripheryTestHelper is DSTest, LiquidityHelper {
             minm: Constants.DEFAULT_MIN_MATURITY,
             maxm: Constants.DEFAULT_MAX_MATURITY,
             mode: Constants.DEFAULT_MODE,
+            rType: Constants.CROP,
             tilt: Constants.DEFAULT_TILT,
             guard: Constants.DEFAULT_GUARD
         });
 
-        cfactory = new CFactory(divider, factoryParams, AddressBook.COMP);
-        ffactory = new FFactory(divider, factoryParams);
+        cfactory = new CFactory(divider, Constants.REWARDS_RECIPIENT, factoryParams, AddressBook.COMP);
+
+        factoryParams.rType = Constants.CROPS;
+        ffactory = new FFactory(divider, Constants.REWARDS_RECIPIENT, factoryParams);
 
         periphery = new Periphery(divider, poolManager, spaceFactory, balancerVault);
 

--- a/pkg/core/src/tests/Periphery.tm.sol
+++ b/pkg/core/src/tests/Periphery.tm.sol
@@ -93,7 +93,6 @@ contract PeripheryTestHelper is DSTest, LiquidityHelper {
             minm: 0, // 0 minm, so there's not lower bound on future maturity
             maxm: type(uint64).max, // large maxm, so there's not upper bound on future maturity
             mode: 0, // monthly maturities
-            rType: Constants.CROP, // reward type
             tilt: 0,
             level: Constants.DEFAULT_LEVEL
         });

--- a/pkg/core/src/tests/Periphery.tm.sol
+++ b/pkg/core/src/tests/Periphery.tm.sol
@@ -117,14 +117,11 @@ contract PeripheryTestHelper is DSTest, LiquidityHelper {
             minm: Constants.DEFAULT_MIN_MATURITY,
             maxm: Constants.DEFAULT_MAX_MATURITY,
             mode: Constants.DEFAULT_MODE,
-            rType: Constants.CROP,
             tilt: Constants.DEFAULT_TILT,
             guard: Constants.DEFAULT_GUARD
         });
 
         cfactory = new CFactory(divider, Constants.REWARDS_RECIPIENT, factoryParams, AddressBook.COMP);
-
-        factoryParams.rType = Constants.CROPS;
         ffactory = new FFactory(divider, Constants.REWARDS_RECIPIENT, factoryParams);
 
         periphery = new Periphery(divider, poolManager, spaceFactory, balancerVault);

--- a/pkg/core/src/tests/adapters/Adapter.t.sol
+++ b/pkg/core/src/tests/adapters/Adapter.t.sol
@@ -183,7 +183,7 @@ contract Adapters is TestHelper {
         assertEq(someReward.balanceOf(address(adapter)), 1e18);
 
         hevm.expectEmit(true, true, true, true);
-        emit RewardsClaimed(address(someReward), Constants.REWARDS_RECIPIENT);
+        emit RewardsClaimed(address(someReward), Constants.REWARDS_RECIPIENT, 1e18);
 
         assertEq(someReward.balanceOf(Constants.REWARDS_RECIPIENT), 0);
         // anyone can call extract token
@@ -205,5 +205,5 @@ contract Adapters is TestHelper {
     /* ========== LOGS ========== */
 
     event RewardsRecipientChanged(address indexed recipient, address indexed newRecipient);
-    event RewardsClaimed(address indexed token, address indexed recipient);
+    event RewardsClaimed(address indexed token, address indexed recipient, uint256 indexed amount);
 }

--- a/pkg/core/src/tests/adapters/Adapter.t.sol
+++ b/pkg/core/src/tests/adapters/Adapter.t.sol
@@ -5,18 +5,22 @@ import { ERC20 } from "@rari-capital/solmate/src/tokens/ERC20.sol";
 import { FixedMath } from "../../external/FixedMath.sol";
 import { Errors } from "@sense-finance/v1-utils/src/libs/Errors.sol";
 import { BaseAdapter } from "../../adapters/abstract/BaseAdapter.sol";
+import { MockAdapter } from "../test-helpers/mocks/MockAdapter.sol";
+import { MockToken } from "../test-helpers/mocks/MockToken.sol";
 import { Divider } from "../../Divider.sol";
-import { TestHelper } from "../test-helpers/TestHelper.sol";
+import { TestHelper, MockTargetLike } from "../test-helpers/TestHelper.sol";
 import { SafeTransferLib } from "@rari-capital/solmate/src/utils/SafeTransferLib.sol";
+import { Constants } from "../test-helpers/Constants.sol";
 
 contract FakeAdapter is BaseAdapter {
     constructor(
         address _divider,
         address _target,
         address _underlying,
+        address _rewardsRecipient,
         uint128 _ifee,
         BaseAdapter.AdapterParams memory _adapterParams
-    ) BaseAdapter(_divider, _target, _underlying, _ifee, _adapterParams) {}
+    ) BaseAdapter(_divider, _target, _underlying, _rewardsRecipient, _ifee, _adapterParams) {}
 
     function scale() external virtual override returns (uint256 _value) {
         return 100e18;
@@ -47,6 +51,50 @@ contract Adapters is TestHelper {
     using SafeTransferLib for ERC20;
     using FixedMath for uint256;
 
+    function testAdapterHasParams() public {
+        MockToken underlying = new MockToken("Dai", "DAI", mockUnderlyingDecimals);
+        MockTargetLike target = MockTargetLike(
+            deployMockTarget(address(underlying), "Compound Dai", "cDAI", mockTargetDecimals)
+        );
+
+        BaseAdapter.AdapterParams memory adapterParams = BaseAdapter.AdapterParams({
+            oracle: ORACLE,
+            stake: address(stake),
+            stakeSize: STAKE_SIZE,
+            minm: MIN_MATURITY,
+            maxm: MAX_MATURITY,
+            mode: MODE,
+            rType: Constants.CROP,
+            tilt: 0,
+            level: DEFAULT_LEVEL
+        });
+
+        MockAdapter adapter = new MockAdapter(
+            address(divider),
+            address(target),
+            !is4626Target ? target.underlying() : target.asset(),
+            Constants.REWARDS_RECIPIENT,
+            ISSUANCE_FEE,
+            adapterParams
+        );
+        (address oracle, address stake, uint256 stakeSize, uint256 minm, uint256 maxm, , , , ) = adapter
+            .adapterParams();
+        assertEq(adapter.name(), "Compound Dai Adapter");
+        assertEq(adapter.symbol(), "cDAI-adapter");
+        assertEq(adapter.target(), address(target));
+        assertEq(adapter.underlying(), address(underlying));
+        assertEq(adapter.divider(), address(divider));
+        assertEq(adapter.rewardsRecipient(), Constants.REWARDS_RECIPIENT);
+        assertEq(adapter.ifee(), ISSUANCE_FEE);
+        assertEq(stake, address(stake));
+        assertEq(stakeSize, STAKE_SIZE);
+        assertEq(minm, MIN_MATURITY);
+        assertEq(maxm, MAX_MATURITY);
+        assertEq(oracle, ORACLE);
+        assertEq(adapter.mode(), MODE);
+        assertEq(adapter.rType(), Constants.CROP);
+    }
+
     function testScale() public {
         assertEq(adapter.scale(), adapter.INITIAL_VALUE());
     }
@@ -65,6 +113,7 @@ contract Adapters is TestHelper {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
+            rType: Constants.NON_CROP,
             tilt: 0,
             level: DEFAULT_LEVEL
         });
@@ -72,6 +121,7 @@ contract Adapters is TestHelper {
             address(divider),
             address(target),
             target.underlying(),
+            Constants.REWARDS_RECIPIENT,
             ISSUANCE_FEE,
             adapterParams
         );
@@ -104,4 +154,58 @@ contract Adapters is TestHelper {
         uint256 uBalReceived = adapter.unwrapTarget(tBal);
         assertEq(uBal, uBalReceived);
     }
+
+    function testSetRewardsRecipient() public {
+        assertEq(adapter.rewardsRecipient(), Constants.REWARDS_RECIPIENT);
+
+        hevm.expectRevert("UNTRUSTED");
+        hevm.prank(address(0x123));
+        adapter.setRewardsRecipient(address(0x111));
+
+        // Can be changed by the factory that deployed it
+        hevm.expectEmit(true, true, true, true);
+        emit RewardsRecipientChanged(address(0x222));
+
+        hevm.prank(address(factory));
+        adapter.setRewardsRecipient(address(0x222));
+        assertEq(adapter.rewardsRecipient(), address(0x222));
+
+        // Can be changed via the factory that deployed it
+        hevm.expectEmit(true, true, true, true);
+        emit RewardsRecipientChanged(address(0x333));
+
+        factory.setAdapterRewardsRecipient(address(adapter), address(0x333));
+        assertEq(adapter.rewardsRecipient(), address(0x333));
+    }
+
+    function testExtractToken() public {
+        // can extract someReward
+        MockToken someReward = new MockToken("Some Reward", "SR", 18);
+        someReward.mint(address(adapter), 1e18);
+        assertEq(someReward.balanceOf(address(adapter)), 1e18);
+
+        hevm.expectEmit(true, true, true, true);
+        emit RewardsClaimed(address(someReward), Constants.REWARDS_RECIPIENT);
+
+        assertEq(someReward.balanceOf(Constants.REWARDS_RECIPIENT), 0);
+        // anyone can call extract token
+        hevm.prank(address(0xfede));
+        adapter.extractToken(address(someReward));
+        assertEq(someReward.balanceOf(Constants.REWARDS_RECIPIENT), 1e18);
+
+        (address target, address stake, ) = adapter.getStakeAndTarget();
+
+        // can NOT extract stake
+        hevm.expectRevert(abi.encodeWithSelector(Errors.TokenNotSupported.selector));
+        adapter.extractToken(address(stake));
+
+        // can NOT extract target
+        hevm.expectRevert(abi.encodeWithSelector(Errors.TokenNotSupported.selector));
+        adapter.extractToken(address(target));
+    }
+
+    /* ========== LOGS ========== */
+
+    event RewardsRecipientChanged(address indexed recipient);
+    event RewardsClaimed(address indexed token, address indexed recipient);
 }

--- a/pkg/core/src/tests/adapters/Adapter.t.sol
+++ b/pkg/core/src/tests/adapters/Adapter.t.sol
@@ -42,6 +42,8 @@ contract FakeAdapter is BaseAdapter {
         return 1e18;
     }
 
+    function extractToken(address token) external override {}
+
     function doSetAdapter(Divider d, address _adapter) public {
         d.setAdapter(_adapter, true);
     }
@@ -64,7 +66,6 @@ contract Adapters is TestHelper {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
-            rType: Constants.CROP,
             tilt: 0,
             level: DEFAULT_LEVEL
         });
@@ -77,8 +78,7 @@ contract Adapters is TestHelper {
             ISSUANCE_FEE,
             adapterParams
         );
-        (address oracle, address stake, uint256 stakeSize, uint256 minm, uint256 maxm, , , , ) = adapter
-            .adapterParams();
+        (address oracle, address stake, uint256 stakeSize, uint256 minm, uint256 maxm, , , ) = adapter.adapterParams();
         assertEq(adapter.name(), "Compound Dai Adapter");
         assertEq(adapter.symbol(), "cDAI-adapter");
         assertEq(adapter.target(), address(target));
@@ -92,7 +92,6 @@ contract Adapters is TestHelper {
         assertEq(maxm, MAX_MATURITY);
         assertEq(oracle, ORACLE);
         assertEq(adapter.mode(), MODE);
-        assertEq(adapter.rType(), Constants.CROP);
     }
 
     function testScale() public {
@@ -113,7 +112,6 @@ contract Adapters is TestHelper {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
-            rType: Constants.NON_CROP,
             tilt: 0,
             level: DEFAULT_LEVEL
         });
@@ -164,7 +162,7 @@ contract Adapters is TestHelper {
 
         // Can be changed by the factory that deployed it
         hevm.expectEmit(true, true, true, true);
-        emit RewardsRecipientChanged(address(0x222));
+        emit RewardsRecipientChanged(Constants.REWARDS_RECIPIENT, address(0x222));
 
         hevm.prank(address(factory));
         adapter.setRewardsRecipient(address(0x222));
@@ -172,7 +170,7 @@ contract Adapters is TestHelper {
 
         // Can be changed via the factory that deployed it
         hevm.expectEmit(true, true, true, true);
-        emit RewardsRecipientChanged(address(0x333));
+        emit RewardsRecipientChanged(address(0x222), address(0x333));
 
         factory.setAdapterRewardsRecipient(address(adapter), address(0x333));
         assertEq(adapter.rewardsRecipient(), address(0x333));
@@ -206,6 +204,6 @@ contract Adapters is TestHelper {
 
     /* ========== LOGS ========== */
 
-    event RewardsRecipientChanged(address indexed recipient);
+    event RewardsRecipientChanged(address indexed recipient, address indexed newRecipient);
     event RewardsClaimed(address indexed token, address indexed recipient);
 }

--- a/pkg/core/src/tests/adapters/CAdapter.tm.sol
+++ b/pkg/core/src/tests/adapters/CAdapter.tm.sol
@@ -15,6 +15,7 @@ import { DSTest } from "../test-helpers/test.sol";
 import { Hevm } from "../test-helpers/Hevm.sol";
 import { DateTimeFull } from "../test-helpers/DateTimeFull.sol";
 import { LiquidityHelper } from "../test-helpers/LiquidityHelper.sol";
+import { Constants } from "../test-helpers/Constants.sol";
 
 interface ComptrollerLike {
     function updateContributorRewards(address contributor) external;
@@ -39,7 +40,7 @@ contract CAdapterTestHelper is LiquidityHelper, DSTest {
     uint256 public constant ONE_CTOKEN = 1e8;
     uint16 public constant DEFAULT_LEVEL = 31;
 
-    uint16 public constant MODE = 0;
+    uint8 public constant MODE = 0;
     uint64 public constant ISSUANCE_FEE = 0.01e18;
     uint256 public constant STAKE_SIZE = 1e18;
     uint256 public constant MIN_MATURITY = 2 weeks;
@@ -70,10 +71,19 @@ contract CAdapterTestHelper is LiquidityHelper, DSTest {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: 0,
+            rType: Constants.CROP,
             tilt: 0,
             level: DEFAULT_LEVEL
         });
-        cDaiAdapter = new CAdapter(address(divider), target, underlying, ISSUANCE_FEE, adapterParams, AddressBook.COMP); // Compound adapter
+        cDaiAdapter = new CAdapter(
+            address(divider),
+            target,
+            underlying,
+            Constants.REWARDS_RECIPIENT,
+            ISSUANCE_FEE,
+            adapterParams,
+            AddressBook.COMP
+        ); // Compound adapter
 
         // Create a CAdapter for an underlying token (USDC) with a non-standard number of decimals
         target = AddressBook.cUSDC;
@@ -82,6 +92,7 @@ contract CAdapterTestHelper is LiquidityHelper, DSTest {
             address(divider),
             target,
             underlying,
+            Constants.REWARDS_RECIPIENT,
             ISSUANCE_FEE,
             adapterParams,
             AddressBook.COMP
@@ -90,7 +101,15 @@ contract CAdapterTestHelper is LiquidityHelper, DSTest {
         target = AddressBook.cETH;
         underlying = AddressBook.WETH;
         adapterParams.minm = 0;
-        cEthAdapter = new CAdapter(address(divider), target, underlying, ISSUANCE_FEE, adapterParams, AddressBook.COMP); // Compound adapter
+        cEthAdapter = new CAdapter(
+            address(divider),
+            target,
+            underlying,
+            Constants.REWARDS_RECIPIENT,
+            ISSUANCE_FEE,
+            adapterParams,
+            AddressBook.COMP
+        ); // Compound adapter
     }
 }
 

--- a/pkg/core/src/tests/adapters/CAdapter.tm.sol
+++ b/pkg/core/src/tests/adapters/CAdapter.tm.sol
@@ -71,7 +71,6 @@ contract CAdapterTestHelper is LiquidityHelper, DSTest {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: 0,
-            rType: Constants.CROP,
             tilt: 0,
             level: DEFAULT_LEVEL
         });

--- a/pkg/core/src/tests/adapters/CropAdapter.t.sol
+++ b/pkg/core/src/tests/adapters/CropAdapter.t.sol
@@ -11,12 +11,13 @@ import { ERC4626CropAdapter } from "../../adapters/abstract/erc4626/ERC4626CropA
 import { Divider } from "../../Divider.sol";
 import { YT } from "../../tokens/YT.sol";
 
-import { MockAdapter, MockCropAdapter } from "../test-helpers/mocks/MockAdapter.sol";
+import { MockCropAdapter } from "../test-helpers/mocks/MockAdapter.sol";
 import { MockFactory } from "../test-helpers/mocks/MockFactory.sol";
 import { MockToken } from "../test-helpers/mocks/MockToken.sol";
 import { MockTarget } from "../test-helpers/mocks/MockTarget.sol";
 import { MockClaimer } from "../test-helpers/mocks/MockClaimer.sol";
 import { TestHelper, MockTargetLike } from "../test-helpers/TestHelper.sol";
+import { Constants } from "../test-helpers/Constants.sol";
 
 contract CropAdapters is TestHelper {
     using FixedMath for uint256;
@@ -44,6 +45,7 @@ contract CropAdapters is TestHelper {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
+            rType: Constants.CROP,
             tilt: 0,
             level: DEFAULT_LEVEL
         });
@@ -52,17 +54,20 @@ contract CropAdapters is TestHelper {
             address(divider),
             address(target),
             !is4626Target ? target.underlying() : target.asset(),
+            Constants.REWARDS_RECIPIENT,
             ISSUANCE_FEE,
             adapterParams,
             address(reward)
         );
-        (address oracle, address stake, uint256 stakeSize, uint256 minm, uint256 maxm, , , ) = adapter.adapterParams();
+        (address oracle, address stake, uint256 stakeSize, uint256 minm, uint256 maxm, , , , ) = adapter
+            .adapterParams();
         assertEq(cropAdapter.reward(), address(reward));
         assertEq(cropAdapter.name(), "Compound Dai Adapter");
         assertEq(cropAdapter.symbol(), "cDAI-adapter");
         assertEq(cropAdapter.target(), address(target));
         assertEq(cropAdapter.underlying(), address(underlying));
         assertEq(cropAdapter.divider(), address(divider));
+        assertEq(cropAdapter.rewardsRecipient(), Constants.REWARDS_RECIPIENT);
         assertEq(cropAdapter.ifee(), ISSUANCE_FEE);
         assertEq(stake, address(stake));
         assertEq(stakeSize, STAKE_SIZE);
@@ -70,6 +75,7 @@ contract CropAdapters is TestHelper {
         assertEq(maxm, MAX_MATURITY);
         assertEq(oracle, ORACLE);
         assertEq(cropAdapter.mode(), MODE);
+        assertEq(cropAdapter.rType(), Constants.CROP);
     }
 
     // distribution tests

--- a/pkg/core/src/tests/adapters/CropAdapter.t.sol
+++ b/pkg/core/src/tests/adapters/CropAdapter.t.sol
@@ -86,7 +86,7 @@ contract CropAdapters is TestHelper {
         assertEq(someReward.balanceOf(address(adapter)), 1e18);
 
         hevm.expectEmit(true, true, true, true);
-        emit RewardsClaimed(address(someReward), Constants.REWARDS_RECIPIENT);
+        emit RewardsClaimed(address(someReward), Constants.REWARDS_RECIPIENT, 1e18);
 
         assertEq(someReward.balanceOf(Constants.REWARDS_RECIPIENT), 0);
         // anyone can call extract token
@@ -1247,5 +1247,5 @@ contract CropAdapters is TestHelper {
     event Distributed(address indexed usr, address indexed token, uint256 amount);
     event RewardTokenChanged(address indexed reward);
     event RewardTokensChanged(address[] indexed rewardTokens);
-    event RewardsClaimed(address indexed token, address indexed recipient);
+    event RewardsClaimed(address indexed token, address indexed recipient, uint256 indexed amount);
 }

--- a/pkg/core/src/tests/adapters/CropAdapter.t.sol
+++ b/pkg/core/src/tests/adapters/CropAdapter.t.sol
@@ -45,7 +45,6 @@ contract CropAdapters is TestHelper {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
-            rType: Constants.CROP,
             tilt: 0,
             level: DEFAULT_LEVEL
         });
@@ -59,8 +58,7 @@ contract CropAdapters is TestHelper {
             adapterParams,
             address(reward)
         );
-        (address oracle, address stake, uint256 stakeSize, uint256 minm, uint256 maxm, , , , ) = adapter
-            .adapterParams();
+        (address oracle, address stake, uint256 stakeSize, uint256 minm, uint256 maxm, , , ) = adapter.adapterParams();
         assertEq(cropAdapter.reward(), address(reward));
         assertEq(cropAdapter.name(), "Compound Dai Adapter");
         assertEq(cropAdapter.symbol(), "cDAI-adapter");
@@ -75,7 +73,6 @@ contract CropAdapters is TestHelper {
         assertEq(maxm, MAX_MATURITY);
         assertEq(oracle, ORACLE);
         assertEq(cropAdapter.mode(), MODE);
-        assertEq(cropAdapter.rType(), Constants.CROP);
 
         // sanity check trusted addresses
         assertTrue(cropAdapter.isTrusted(address(divider)));

--- a/pkg/core/src/tests/adapters/CropAdapter.t.sol
+++ b/pkg/core/src/tests/adapters/CropAdapter.t.sol
@@ -76,6 +76,10 @@ contract CropAdapters is TestHelper {
         assertEq(oracle, ORACLE);
         assertEq(cropAdapter.mode(), MODE);
         assertEq(cropAdapter.rType(), Constants.CROP);
+
+        // sanity check trusted addresses
+        assertTrue(cropAdapter.isTrusted(address(divider)));
+        assertTrue(cropAdapter.isTrusted(address(this)));
     }
 
     function testExtractToken() public {

--- a/pkg/core/src/tests/adapters/CropsAdapter.t.sol
+++ b/pkg/core/src/tests/adapters/CropsAdapter.t.sol
@@ -104,7 +104,7 @@ contract CropsAdapters is TestHelper {
         assertEq(someReward.balanceOf(address(cropsAdapter)), 1e18);
 
         hevm.expectEmit(true, true, true, true);
-        emit RewardsClaimed(address(someReward), Constants.REWARDS_RECIPIENT);
+        emit RewardsClaimed(address(someReward), Constants.REWARDS_RECIPIENT, 1e18);
 
         assertEq(someReward.balanceOf(Constants.REWARDS_RECIPIENT), 0);
         // anyone can call extract token
@@ -1412,5 +1412,5 @@ contract CropsAdapters is TestHelper {
     event ClaimerChanged(address indexed claimer);
     event Distributed(address indexed usr, address indexed token, uint256 amount);
     event RewardTokensChanged(address[] indexed rewardTokens);
-    event RewardsClaimed(address indexed token, address indexed recipient);
+    event RewardsClaimed(address indexed token, address indexed recipient, uint256 indexed amount);
 }

--- a/pkg/core/src/tests/adapters/CropsAdapter.t.sol
+++ b/pkg/core/src/tests/adapters/CropsAdapter.t.sol
@@ -16,6 +16,7 @@ import { MockToken } from "../test-helpers/mocks/MockToken.sol";
 import { MockTarget } from "../test-helpers/mocks/MockTarget.sol";
 import { MockClaimer } from "../test-helpers/mocks/MockClaimer.sol";
 import { TestHelper, MockTargetLike } from "../test-helpers/TestHelper.sol";
+import { Constants } from "../test-helpers/Constants.sol";
 
 contract CropsAdapters is TestHelper {
     using FixedMath for uint256;
@@ -63,6 +64,7 @@ contract CropsAdapters is TestHelper {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
+            rType: Constants.CROPS,
             tilt: 0,
             level: DEFAULT_LEVEL
         });
@@ -71,12 +73,13 @@ contract CropsAdapters is TestHelper {
             address(divider),
             address(target),
             !is4626Target ? target.underlying() : target.asset(),
+            Constants.REWARDS_RECIPIENT,
             ISSUANCE_FEE,
             adapterParams,
             rewardTokens
         );
 
-        (address oracle, address stake, uint256 stakeSize, uint256 minm, uint256 maxm, , , ) = cropsAdapter
+        (address oracle, address stake, uint256 stakeSize, uint256 minm, uint256 maxm, , , , ) = cropsAdapter
             .adapterParams();
         assertEq(cropsAdapter.rewardTokens(0), address(reward));
         assertEq(cropsAdapter.rewardTokens(1), address(reward2));
@@ -85,6 +88,7 @@ contract CropsAdapters is TestHelper {
         assertEq(cropsAdapter.target(), address(target));
         assertEq(cropsAdapter.underlying(), address(underlying));
         assertEq(cropsAdapter.divider(), address(divider));
+        assertEq(cropsAdapter.rewardsRecipient(), Constants.REWARDS_RECIPIENT);
         assertEq(cropsAdapter.ifee(), ISSUANCE_FEE);
         assertEq(stake, address(stake));
         assertEq(stakeSize, STAKE_SIZE);
@@ -92,6 +96,7 @@ contract CropsAdapters is TestHelper {
         assertEq(maxm, MAX_MATURITY);
         assertEq(oracle, ORACLE);
         assertEq(cropsAdapter.mode(), MODE);
+        assertEq(cropsAdapter.rType(), Constants.CROPS);
     }
 
     // distribution tests

--- a/pkg/core/src/tests/adapters/CropsAdapter.t.sol
+++ b/pkg/core/src/tests/adapters/CropsAdapter.t.sol
@@ -64,7 +64,6 @@ contract CropsAdapters is TestHelper {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
-            rType: Constants.CROPS,
             tilt: 0,
             level: DEFAULT_LEVEL
         });
@@ -79,7 +78,7 @@ contract CropsAdapters is TestHelper {
             rewardTokens
         );
 
-        (address oracle, address stake, uint256 stakeSize, uint256 minm, uint256 maxm, , , , ) = cropsAdapter
+        (address oracle, address stake, uint256 stakeSize, uint256 minm, uint256 maxm, , , ) = cropsAdapter
             .adapterParams();
         assertEq(cropsAdapter.rewardTokens(0), address(reward));
         assertEq(cropsAdapter.rewardTokens(1), address(reward2));
@@ -96,7 +95,6 @@ contract CropsAdapters is TestHelper {
         assertEq(maxm, MAX_MATURITY);
         assertEq(oracle, ORACLE);
         assertEq(cropsAdapter.mode(), MODE);
-        assertEq(cropsAdapter.rType(), Constants.CROPS);
     }
 
     function testExtractToken() public {

--- a/pkg/core/src/tests/adapters/ERC4626Adapter.t.sol
+++ b/pkg/core/src/tests/adapters/ERC4626Adapter.t.sol
@@ -71,7 +71,6 @@ contract ERC4626AdapterTest is DSTestPlus {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
-            rType: Constants.NON_CROP,
             tilt: 0,
             level: Constants.DEFAULT_LEVEL
         });

--- a/pkg/core/src/tests/adapters/ERC4626Adapter.t.sol
+++ b/pkg/core/src/tests/adapters/ERC4626Adapter.t.sol
@@ -41,7 +41,7 @@ contract ERC4626AdapterTest is DSTestPlus {
     uint256 public constant STAKE_SIZE = 1e18;
     uint256 public constant MIN_MATURITY = 2 weeks;
     uint256 public constant MAX_MATURITY = 14 weeks;
-    uint16 public constant MODE = 0;
+    uint8 public constant MODE = 0;
 
     uint256 public constant INITIAL_BALANCE = 1.25e18;
 
@@ -71,11 +71,18 @@ contract ERC4626AdapterTest is DSTestPlus {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
+            rType: Constants.NON_CROP,
             tilt: 0,
             level: Constants.DEFAULT_LEVEL
         });
 
-        erc4626Adapter = new ERC4626Adapter(address(divider), address(target), ISSUANCE_FEE, adapterParams);
+        erc4626Adapter = new ERC4626Adapter(
+            address(divider),
+            address(target),
+            Constants.REWARDS_RECIPIENT,
+            ISSUANCE_FEE,
+            adapterParams
+        );
     }
 
     function testWrapUnwrap(uint256 wrapAmt) public {

--- a/pkg/core/src/tests/adapters/ERC4626Adapter.tm.sol
+++ b/pkg/core/src/tests/adapters/ERC4626Adapter.tm.sol
@@ -81,7 +81,6 @@ contract ERC4626Adapters is LiquidityHelper, DSTest {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: 0,
-            rType: Constants.NON_CROP,
             tilt: 0,
             level: DEFAULT_LEVEL
         });

--- a/pkg/core/src/tests/adapters/ERC4626Adapter.tm.sol
+++ b/pkg/core/src/tests/adapters/ERC4626Adapter.tm.sol
@@ -37,7 +37,7 @@ contract ERC4626Adapters is LiquidityHelper, DSTest {
     uint256 public constant STAKE_SIZE = 1e18;
     uint256 public constant MIN_MATURITY = 2 weeks;
     uint256 public constant MAX_MATURITY = 14 weeks;
-    uint16 public constant MODE = 0;
+    uint8 public constant MODE = 0;
     uint16 public constant DEFAULT_LEVEL = 31;
     uint256 public constant INITIAL_BALANCE = 1.25e18;
 
@@ -81,10 +81,17 @@ contract ERC4626Adapters is LiquidityHelper, DSTest {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: 0,
+            rType: Constants.NON_CROP,
             tilt: 0,
             level: DEFAULT_LEVEL
         });
-        erc4626Adapter = new ERC4626Adapter(address(divider), AddressBook.IMUSD, ISSUANCE_FEE, adapterParams); // imUSD ERC-4626 adapter
+        erc4626Adapter = new ERC4626Adapter(
+            address(divider),
+            AddressBook.IMUSD,
+            Constants.REWARDS_RECIPIENT,
+            ISSUANCE_FEE,
+            adapterParams
+        ); // imUSD ERC-4626 adapter
     }
 
     function testMainnetERC4626AdapterScale() public {

--- a/pkg/core/src/tests/adapters/FAdapter.tm.sol
+++ b/pkg/core/src/tests/adapters/FAdapter.tm.sol
@@ -77,7 +77,6 @@ contract FAdapterTestHelper is LiquidityHelper, DSTest {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: 0,
-            rType: Constants.CROPS,
             tilt: 0,
             level: DEFAULT_LEVEL
         });

--- a/pkg/core/src/tests/adapters/FAdapter.tm.sol
+++ b/pkg/core/src/tests/adapters/FAdapter.tm.sol
@@ -16,6 +16,7 @@ import { DSTest } from "../test-helpers/test.sol";
 import { Hevm } from "../test-helpers/Hevm.sol";
 import { DateTimeFull } from "../test-helpers/DateTimeFull.sol";
 import { LiquidityHelper } from "../test-helpers/LiquidityHelper.sol";
+import { Constants } from "../test-helpers/Constants.sol";
 
 interface RewardsDistributorLike {
     function accrue(ERC20 market, address user) external returns (uint256);
@@ -35,7 +36,7 @@ contract FAdapterTestHelper is LiquidityHelper, DSTest {
     uint16 public constant DEFAULT_LEVEL = 31;
     uint256 public constant INITIAL_BALANCE = 1.25e18;
 
-    uint16 public constant MODE = 0;
+    uint8 public constant MODE = 0;
     uint64 public constant ISSUANCE_FEE = 0.01e18;
     uint256 public constant STAKE_SIZE = 1e18;
     uint256 public constant MIN_MATURITY = 2 weeks;
@@ -76,6 +77,7 @@ contract FAdapterTestHelper is LiquidityHelper, DSTest {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: 0,
+            rType: Constants.CROPS,
             tilt: 0,
             level: DEFAULT_LEVEL
         });
@@ -83,6 +85,7 @@ contract FAdapterTestHelper is LiquidityHelper, DSTest {
             address(divider),
             target,
             underlying,
+            Constants.REWARDS_RECIPIENT,
             ISSUANCE_FEE,
             AddressBook.OLYMPUS_POOL_PARTY,
             adapterParams,
@@ -96,6 +99,7 @@ contract FAdapterTestHelper is LiquidityHelper, DSTest {
             address(divider),
             target,
             underlying,
+            Constants.REWARDS_RECIPIENT,
             ISSUANCE_FEE,
             AddressBook.OLYMPUS_POOL_PARTY,
             adapterParams,
@@ -110,6 +114,7 @@ contract FAdapterTestHelper is LiquidityHelper, DSTest {
             address(divider),
             target,
             underlying,
+            Constants.REWARDS_RECIPIENT,
             ISSUANCE_FEE,
             AddressBook.OLYMPUS_POOL_PARTY,
             adapterParams,
@@ -123,6 +128,7 @@ contract FAdapterTestHelper is LiquidityHelper, DSTest {
             address(divider),
             target,
             underlying,
+            Constants.REWARDS_RECIPIENT,
             ISSUANCE_FEE,
             AddressBook.TRIBE_CONVEX,
             adapterParams,
@@ -146,6 +152,7 @@ contract FAdapterTestHelper is LiquidityHelper, DSTest {
             address(divider),
             target,
             underlying,
+            Constants.REWARDS_RECIPIENT,
             ISSUANCE_FEE,
             AddressBook.TRIBE_CONVEX,
             adapterParams,

--- a/pkg/core/src/tests/adapters/WstETHAdapter.tm.sol
+++ b/pkg/core/src/tests/adapters/WstETHAdapter.tm.sol
@@ -18,6 +18,7 @@ import { MockFactory } from "../test-helpers/mocks/MockFactory.sol";
 import { Hevm } from "../test-helpers/Hevm.sol";
 import { DateTimeFull } from "../test-helpers/DateTimeFull.sol";
 import { LiquidityHelper } from "../test-helpers/LiquidityHelper.sol";
+import { Constants } from "../test-helpers/Constants.sol";
 
 interface PriceOracleLike {
     function latestRoundData()
@@ -64,7 +65,7 @@ contract WstETHAdapterTestHelper is LiquidityHelper, DSTest {
     uint256 public constant MIN_MATURITY = 2 weeks;
     uint256 public constant MAX_MATURITY = 14 weeks;
     uint48 public constant DEFAULT_LEVEL = 31;
-    uint16 public constant DEFAULT_MODE = 0;
+    uint8 public constant DEFAULT_MODE = 0;
     uint64 public constant DEFAULT_TILT = 0;
 
     Hevm internal constant hevm = Hevm(HEVM_ADDRESS);
@@ -84,10 +85,17 @@ contract WstETHAdapterTestHelper is LiquidityHelper, DSTest {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: DEFAULT_MODE,
+            rType: Constants.NON_CROP,
             tilt: DEFAULT_TILT,
             level: DEFAULT_LEVEL
         });
-        adapter = new WstETHAdapter(address(divider), AddressBook.WSTETH, ISSUANCE_FEE, adapterParams); // wstETH adapter
+        adapter = new WstETHAdapter(
+            address(divider),
+            AddressBook.WSTETH,
+            Constants.REWARDS_RECIPIENT,
+            ISSUANCE_FEE,
+            adapterParams
+        ); // wstETH adapter
     }
 
     function sendEther(address to, uint256 amt) external returns (bool) {

--- a/pkg/core/src/tests/adapters/WstETHAdapter.tm.sol
+++ b/pkg/core/src/tests/adapters/WstETHAdapter.tm.sol
@@ -85,7 +85,6 @@ contract WstETHAdapterTestHelper is LiquidityHelper, DSTest {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: DEFAULT_MODE,
-            rType: Constants.NON_CROP,
             tilt: DEFAULT_TILT,
             level: DEFAULT_LEVEL
         });

--- a/pkg/core/src/tests/factories/BaseFactory.t.sol
+++ b/pkg/core/src/tests/factories/BaseFactory.t.sol
@@ -97,7 +97,6 @@ contract Factories is TestHelper {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
-            rType: Constants.CROP,
             tilt: 0,
             guard: 123e18
         });
@@ -118,7 +117,6 @@ contract Factories is TestHelper {
             uint256 maxm,
             uint256 ifee,
             uint8 mode,
-            uint8 rType,
             uint64 tilt,
             uint256 guard
         ) = someFactory.factoryParams();
@@ -130,7 +128,6 @@ contract Factories is TestHelper {
         assertEq(minm, MIN_MATURITY);
         assertEq(maxm, MAX_MATURITY);
         assertEq(mode, MODE);
-        assertEq(rType, Constants.CROP);
         assertEq(tilt, 0);
         assertEq(guard, 123e18);
         assertEq(someFactory.reward(), address(reward));
@@ -162,7 +159,6 @@ contract Factories is TestHelper {
                 minm: MIN_MATURITY,
                 maxm: MAX_MATURITY,
                 mode: MODE,
-                rType: Constants.CROP,
                 tilt: 0,
                 guard: DEFAULT_GUARD
             });
@@ -336,6 +332,5 @@ contract Factories is TestHelper {
 
     /* ========== LOGS ========== */
 
-    event AdminChanged(address indexed adapter);
     event RewardsRecipientChanged(address indexed recipient);
 }

--- a/pkg/core/src/tests/factories/BaseFactory.t.sol
+++ b/pkg/core/src/tests/factories/BaseFactory.t.sol
@@ -67,7 +67,6 @@ contract Mock2e18Factory is MockCropFactory {
             minm: factoryParams.minm,
             maxm: factoryParams.maxm,
             mode: factoryParams.mode,
-            rType: Constants.CROP,
             tilt: factoryParams.tilt,
             level: DEFAULT_LEVEL
         });
@@ -116,7 +115,7 @@ contract Factories is TestHelper {
             uint256 minm,
             uint256 maxm,
             uint256 ifee,
-            uint8 mode,
+            uint16 mode,
             uint64 tilt,
             uint256 guard
         ) = someFactory.factoryParams();
@@ -180,8 +179,7 @@ contract Factories is TestHelper {
         );
         assertTrue(address(adapter) != address(0));
 
-        (address oracle, address stake, uint256 stakeSize, uint256 minm, uint256 maxm, , , , ) = adapter
-            .adapterParams();
+        (address oracle, address stake, uint256 stakeSize, uint256 minm, uint256 maxm, , , ) = adapter.adapterParams();
         assertEq(adapter.divider(), address(divider));
         assertEq(adapter.rewardsRecipient(), Constants.REWARDS_RECIPIENT);
         assertEq(adapter.target(), address(someTarget));
@@ -194,7 +192,6 @@ contract Factories is TestHelper {
         assertEq(minm, MIN_MATURITY);
         assertEq(maxm, MAX_MATURITY);
         assertEq(adapter.mode(), MODE);
-        assertEq(adapter.rType(), Constants.CROP);
 
         if (is4626Target) {
             assertEq(ERC4626CropAdapter(address(adapter)).reward(), address(someReward));
@@ -258,7 +255,7 @@ contract Factories is TestHelper {
         address adapter = someFactory.deployAdapter(address(someTarget), "");
         assertTrue(adapter != address(0));
 
-        (address oracle, address stake, uint256 stakeSize, uint256 minm, uint256 maxm, , , , ) = MockAdapter(adapter)
+        (address oracle, address stake, uint256 stakeSize, uint256 minm, uint256 maxm, , , ) = MockAdapter(adapter)
             .adapterParams();
         assertEq(MockAdapter(adapter).divider(), address(divider));
         assertEq(MockAdapter(adapter).target(), address(someTarget));
@@ -271,7 +268,6 @@ contract Factories is TestHelper {
         assertEq(minm, MIN_MATURITY);
         assertEq(maxm, MAX_MATURITY);
         assertEq(MockAdapter(adapter).mode(), MODE);
-        assertEq(MockAdapter(adapter).rType(), Constants.NON_CROP);
 
         uint256 scale = MockAdapter(adapter).scale();
         assertEq(scale, 1e18);
@@ -324,7 +320,7 @@ contract Factories is TestHelper {
 
         // Can set rewards recipient
         hevm.expectEmit(true, true, true, true);
-        emit RewardsRecipientChanged(address(0x111));
+        emit RewardsRecipientChanged(Constants.REWARDS_RECIPIENT, address(0x111));
 
         factory.setRewardsRecipient(address(0x111));
         assertEq(factory.rewardsRecipient(), address(0x111));
@@ -332,5 +328,5 @@ contract Factories is TestHelper {
 
     /* ========== LOGS ========== */
 
-    event RewardsRecipientChanged(address indexed recipient);
+    event RewardsRecipientChanged(address indexed recipient, address indexed newRecipient);
 }

--- a/pkg/core/src/tests/factories/CFactory.tm.sol
+++ b/pkg/core/src/tests/factories/CFactory.tm.sol
@@ -89,7 +89,7 @@ contract CFactories is CAdapterTestHelper {
             uint256 minm,
             uint256 maxm,
             uint256 ifee,
-            uint8 mode,
+            uint16 mode,
             uint64 tilt,
             uint256 guard
         ) = CFactory(otherCFactory).factoryParams();

--- a/pkg/core/src/tests/factories/CFactory.tm.sol
+++ b/pkg/core/src/tests/factories/CFactory.tm.sol
@@ -15,6 +15,7 @@ import { DateTimeFull } from "../test-helpers/DateTimeFull.sol";
 import { AddressBook } from "../test-helpers/AddressBook.sol";
 import { Errors } from "@sense-finance/v1-utils/src/libs/Errors.sol";
 import { ERC20 } from "@rari-capital/solmate/src/tokens/ERC20.sol";
+import { Constants } from "../test-helpers/Constants.sol";
 
 contract CAdapterTestHelper is DSTest {
     CFactory internal factory;
@@ -23,7 +24,7 @@ contract CAdapterTestHelper is DSTest {
 
     Hevm internal constant hevm = Hevm(HEVM_ADDRESS);
 
-    uint16 public constant MODE = 0;
+    uint8 public constant MODE = 0;
     uint64 public constant ISSUANCE_FEE = 0.01e18;
     uint256 public constant STAKE_SIZE = 1e18;
     uint256 public constant MIN_MATURITY = 2 weeks;
@@ -47,10 +48,11 @@ contract CAdapterTestHelper is DSTest {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
+            rType: Constants.CROP,
             tilt: 0,
             guard: DEFAULT_GUARD
         });
-        factory = new CFactory(address(divider), factoryParams, AddressBook.COMP);
+        factory = new CFactory(address(divider), Constants.REWARDS_RECIPIENT, factoryParams, AddressBook.COMP);
         divider.setIsTrusted(address(factory), true); // add factory as a ward
     }
 }
@@ -70,10 +72,16 @@ contract CFactories is CAdapterTestHelper {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
+            rType: Constants.CROP,
             tilt: 0,
             guard: DEFAULT_GUARD
         });
-        CFactory otherCFactory = new CFactory(address(divider), factoryParams, AddressBook.COMP);
+        CFactory otherCFactory = new CFactory(
+            address(divider),
+            Constants.REWARDS_RECIPIENT,
+            factoryParams,
+            AddressBook.COMP
+        );
 
         assertTrue(address(otherCFactory) != address(0));
         (
@@ -83,7 +91,8 @@ contract CFactories is CAdapterTestHelper {
             uint256 minm,
             uint256 maxm,
             uint256 ifee,
-            uint16 mode,
+            uint8 mode,
+            uint8 rType,
             uint64 tilt,
             uint256 guard
         ) = CFactory(otherCFactory).factoryParams();
@@ -95,6 +104,7 @@ contract CFactories is CAdapterTestHelper {
         assertEq(minm, MIN_MATURITY);
         assertEq(maxm, MAX_MATURITY);
         assertEq(mode, MODE);
+        assertEq(rType, Constants.CROP);
         assertEq(oracle, AddressBook.RARI_ORACLE);
         assertEq(tilt, 0);
         assertEq(guard, DEFAULT_GUARD);

--- a/pkg/core/src/tests/factories/CFactory.tm.sol
+++ b/pkg/core/src/tests/factories/CFactory.tm.sol
@@ -48,7 +48,6 @@ contract CAdapterTestHelper is DSTest {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
-            rType: Constants.CROP,
             tilt: 0,
             guard: DEFAULT_GUARD
         });
@@ -72,7 +71,6 @@ contract CFactories is CAdapterTestHelper {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
-            rType: Constants.CROP,
             tilt: 0,
             guard: DEFAULT_GUARD
         });
@@ -92,7 +90,6 @@ contract CFactories is CAdapterTestHelper {
             uint256 maxm,
             uint256 ifee,
             uint8 mode,
-            uint8 rType,
             uint64 tilt,
             uint256 guard
         ) = CFactory(otherCFactory).factoryParams();
@@ -104,7 +101,6 @@ contract CFactories is CAdapterTestHelper {
         assertEq(minm, MIN_MATURITY);
         assertEq(maxm, MAX_MATURITY);
         assertEq(mode, MODE);
-        assertEq(rType, Constants.CROP);
         assertEq(oracle, AddressBook.RARI_ORACLE);
         assertEq(tilt, 0);
         assertEq(guard, DEFAULT_GUARD);

--- a/pkg/core/src/tests/factories/ERC4626Factory.t.sol
+++ b/pkg/core/src/tests/factories/ERC4626Factory.t.sol
@@ -49,7 +49,7 @@ contract ERC4626FactoryTest is TestHelper {
             uint256 minm,
             uint256 maxm,
             uint256 ifee,
-            uint8 mode,
+            uint16 mode,
             uint64 tilt,
             uint256 guard
         ) = ERC4626Factory(someFactory).factoryParams();
@@ -76,7 +76,7 @@ contract ERC4626FactoryTest is TestHelper {
         address adapter = someFactory.deployAdapter(address(someTarget), "");
         assertTrue(adapter != address(0));
 
-        (address oracle, address stake, uint256 stakeSize, uint256 minm, uint256 maxm, , , , ) = MockAdapter(adapter)
+        (address oracle, address stake, uint256 stakeSize, uint256 minm, uint256 maxm, , , ) = MockAdapter(adapter)
             .adapterParams();
         assertEq(MockAdapter(adapter).divider(), address(divider));
         assertEq(MockAdapter(adapter).target(), address(someTarget));
@@ -89,7 +89,6 @@ contract ERC4626FactoryTest is TestHelper {
         assertEq(minm, MIN_MATURITY);
         assertEq(maxm, MAX_MATURITY);
         assertEq(MockAdapter(adapter).mode(), MODE);
-        assertEq(MockAdapter(adapter).rType(), MODE);
         uint256 scale = MockAdapter(adapter).scale();
         assertEq(scale, 1e18);
     }
@@ -109,8 +108,7 @@ contract ERC4626FactoryTest is TestHelper {
         ERC4626CropAdapter adapter = ERC4626CropAdapter(someFactory.deployAdapter(address(someTarget), data));
         assertTrue(address(adapter) != address(0));
 
-        (address oracle, address stake, uint256 stakeSize, uint256 minm, uint256 maxm, , , , ) = adapter
-            .adapterParams();
+        (address oracle, address stake, uint256 stakeSize, uint256 minm, uint256 maxm, , , ) = adapter.adapterParams();
         assertEq(adapter.divider(), address(divider));
         assertEq(adapter.rewardsRecipient(), Constants.REWARDS_RECIPIENT);
         assertEq(adapter.target(), address(someTarget));
@@ -123,7 +121,6 @@ contract ERC4626FactoryTest is TestHelper {
         assertEq(minm, MIN_MATURITY);
         assertEq(maxm, MAX_MATURITY);
         assertEq(adapter.mode(), MODE);
-        assertEq(adapter.rType(), Constants.CROP);
         assertEq(adapter.reward(), address(someReward));
         uint256 scale = adapter.scale();
         assertEq(scale, 1e18);
@@ -148,8 +145,7 @@ contract ERC4626FactoryTest is TestHelper {
         ERC4626CropsAdapter adapter = ERC4626CropsAdapter(someFactory.deployAdapter(address(someTarget), data));
         assertTrue(address(adapter) != address(0));
 
-        (address oracle, address stake, uint256 stakeSize, uint256 minm, uint256 maxm, , , , ) = adapter
-            .adapterParams();
+        (address oracle, address stake, uint256 stakeSize, uint256 minm, uint256 maxm, , , ) = adapter.adapterParams();
         assertEq(adapter.divider(), address(divider));
         assertEq(adapter.rewardsRecipient(), Constants.REWARDS_RECIPIENT);
         assertEq(adapter.target(), address(someTarget));
@@ -162,7 +158,6 @@ contract ERC4626FactoryTest is TestHelper {
         assertEq(minm, MIN_MATURITY);
         assertEq(maxm, MAX_MATURITY);
         assertEq(adapter.mode(), MODE);
-        assertEq(adapter.rType(), Constants.CROPS);
         assertEq(adapter.rewardTokens(0), address(someReward));
         assertEq(adapter.rewardTokens(1), address(someReward2));
         uint256 scale = adapter.scale();

--- a/pkg/core/src/tests/factories/ERC4626Factory.t.sol
+++ b/pkg/core/src/tests/factories/ERC4626Factory.t.sol
@@ -35,7 +35,6 @@ contract ERC4626FactoryTest is TestHelper {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
-            rType: Constants.NON_CROP,
             tilt: 0,
             guard: 123e18
         });
@@ -51,7 +50,6 @@ contract ERC4626FactoryTest is TestHelper {
             uint256 maxm,
             uint256 ifee,
             uint8 mode,
-            uint8 rType,
             uint64 tilt,
             uint256 guard
         ) = ERC4626Factory(someFactory).factoryParams();
@@ -63,7 +61,6 @@ contract ERC4626FactoryTest is TestHelper {
         assertEq(minm, MIN_MATURITY);
         assertEq(maxm, MAX_MATURITY);
         assertEq(mode, MODE);
-        assertEq(rType, Constants.NON_CROP);
         assertEq(tilt, 0);
         assertEq(guard, 123e18);
     }

--- a/pkg/core/src/tests/factories/ERC4626Factory.tm.sol
+++ b/pkg/core/src/tests/factories/ERC4626Factory.tm.sol
@@ -72,7 +72,6 @@ contract ERC4626TestHelper is DSTest {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
-            rType: Constants.NON_CROP,
             tilt: 0,
             guard: DEFAULT_GUARD
         });
@@ -98,7 +97,6 @@ contract ERC4626Factories is ERC4626TestHelper {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
-            rType: Constants.NON_CROP,
             tilt: 0,
             guard: DEFAULT_GUARD
         });
@@ -113,7 +111,6 @@ contract ERC4626Factories is ERC4626TestHelper {
             uint256 maxm,
             uint256 ifee,
             uint8 mode,
-            uint8 rType,
             uint64 tilt,
             uint256 guard
         ) = ERC4626Factory(otherFactory).factoryParams();
@@ -125,7 +122,6 @@ contract ERC4626Factories is ERC4626TestHelper {
         assertEq(minm, MIN_MATURITY);
         assertEq(maxm, MAX_MATURITY);
         assertEq(mode, MODE);
-        assertEq(rType, Constants.NON_CROP);
         assertEq(oracle, address(masterOracle));
         assertEq(tilt, 0);
         assertEq(guard, DEFAULT_GUARD);

--- a/pkg/core/src/tests/factories/ERC4626Factory.tm.sol
+++ b/pkg/core/src/tests/factories/ERC4626Factory.tm.sol
@@ -19,6 +19,7 @@ import { Hevm } from "../test-helpers/Hevm.sol";
 import { DateTimeFull } from "../test-helpers/DateTimeFull.sol";
 import { AddressBook } from "../test-helpers/AddressBook.sol";
 import { Errors } from "@sense-finance/v1-utils/src/libs/Errors.sol";
+import { Constants } from "../test-helpers/Constants.sol";
 
 contract ERC4626TestHelper is DSTest {
     uint256 public mainnetFork;
@@ -31,7 +32,7 @@ contract ERC4626TestHelper is DSTest {
 
     Hevm internal constant hevm = Hevm(HEVM_ADDRESS);
 
-    uint16 public constant MODE = 0;
+    uint8 public constant MODE = 0;
     uint64 public constant ISSUANCE_FEE = 0.01e18;
     uint256 public constant STAKE_SIZE = 1e18;
     uint256 public constant MIN_MATURITY = 2 weeks;
@@ -71,14 +72,15 @@ contract ERC4626TestHelper is DSTest {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
+            rType: Constants.NON_CROP,
             tilt: 0,
             guard: DEFAULT_GUARD
         });
-        factory = new ERC4626Factory(address(divider), factoryParams);
+        factory = new ERC4626Factory(address(divider), Constants.REWARDS_RECIPIENT, factoryParams);
         divider.setIsTrusted(address(factory), true); // add factory as a ward
         factory.supportTarget(AddressBook.IMUSD, true);
 
-        cropsFactory = new ERC4626CropsFactory(address(divider), factoryParams);
+        cropsFactory = new ERC4626CropsFactory(address(divider), Constants.REWARDS_RECIPIENT, factoryParams);
         divider.setIsTrusted(address(cropsFactory), true); // add factory as a ward
         cropsFactory.supportTarget(AddressBook.IMUSD, true);
     }
@@ -96,10 +98,11 @@ contract ERC4626Factories is ERC4626TestHelper {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
+            rType: Constants.NON_CROP,
             tilt: 0,
             guard: DEFAULT_GUARD
         });
-        ERC4626Factory otherFactory = new ERC4626Factory(address(divider), factoryParams);
+        ERC4626Factory otherFactory = new ERC4626Factory(address(divider), Constants.REWARDS_RECIPIENT, factoryParams);
 
         assertTrue(address(otherFactory) != address(0));
         (
@@ -109,7 +112,8 @@ contract ERC4626Factories is ERC4626TestHelper {
             uint256 minm,
             uint256 maxm,
             uint256 ifee,
-            uint16 mode,
+            uint8 mode,
+            uint8 rType,
             uint64 tilt,
             uint256 guard
         ) = ERC4626Factory(otherFactory).factoryParams();
@@ -121,6 +125,7 @@ contract ERC4626Factories is ERC4626TestHelper {
         assertEq(minm, MIN_MATURITY);
         assertEq(maxm, MAX_MATURITY);
         assertEq(mode, MODE);
+        assertEq(rType, Constants.NON_CROP);
         assertEq(oracle, address(masterOracle));
         assertEq(tilt, 0);
         assertEq(guard, DEFAULT_GUARD);

--- a/pkg/core/src/tests/factories/ERC4626Factory.tm.sol
+++ b/pkg/core/src/tests/factories/ERC4626Factory.tm.sol
@@ -110,7 +110,7 @@ contract ERC4626Factories is ERC4626TestHelper {
             uint256 minm,
             uint256 maxm,
             uint256 ifee,
-            uint8 mode,
+            uint16 mode,
             uint64 tilt,
             uint256 guard
         ) = ERC4626Factory(otherFactory).factoryParams();

--- a/pkg/core/src/tests/factories/FFactory.tm.sol
+++ b/pkg/core/src/tests/factories/FFactory.tm.sol
@@ -45,7 +45,6 @@ contract FAdapterTestHelper is DSTest {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
-            rType: Constants.CROPS,
             tilt: 0,
             guard: DEFAULT_GUARD
         });
@@ -64,7 +63,6 @@ contract FFactories is FAdapterTestHelper {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
-            rType: Constants.CROPS,
             tilt: 0,
             guard: DEFAULT_GUARD
         });
@@ -78,8 +76,7 @@ contract FFactories is FAdapterTestHelper {
             uint256 minm,
             uint256 maxm,
             uint256 ifee,
-            uint8 mode,
-            uint8 rType,
+            uint16 mode,
             uint64 tilt,
             uint256 guard
         ) = FFactory(otherFFactory).factoryParams();
@@ -91,7 +88,6 @@ contract FFactories is FAdapterTestHelper {
         assertEq(minm, MIN_MATURITY);
         assertEq(maxm, MAX_MATURITY);
         assertEq(mode, MODE);
-        assertEq(rType, Constants.CROPS);
         assertEq(oracle, AddressBook.RARI_ORACLE);
         assertEq(tilt, 0);
         assertEq(guard, DEFAULT_GUARD);

--- a/pkg/core/src/tests/test-helpers/Constants.sol
+++ b/pkg/core/src/tests/test-helpers/Constants.sol
@@ -5,10 +5,6 @@ pragma solidity 0.8.11;
 library Constants {
     // adapter config
     address public constant REWARDS_RECIPIENT = address(0xfed);
-    uint8 public constant NON_CROP = 0;
-    uint8 public constant CROP = 1;
-    uint8 public constant CROPS = 2;
-
     uint16 public constant DEFAULT_LEVEL = 31;
     uint256 public constant DEFAULT_STAKE_SIZE = 1e18;
     uint256 public constant DEFAULT_MIN_MATURITY = 2 weeks;

--- a/pkg/core/src/tests/test-helpers/Constants.sol
+++ b/pkg/core/src/tests/test-helpers/Constants.sol
@@ -4,13 +4,18 @@ pragma solidity 0.8.11;
 /// @notice System constants
 library Constants {
     // adapter config
+    address public constant REWARDS_RECIPIENT = address(0xfed);
+    uint8 public constant NON_CROP = 0;
+    uint8 public constant CROP = 1;
+    uint8 public constant CROPS = 2;
+
     uint16 public constant DEFAULT_LEVEL = 31;
     uint256 public constant DEFAULT_STAKE_SIZE = 1e18;
     uint256 public constant DEFAULT_MIN_MATURITY = 2 weeks;
     uint256 public constant DEFAULT_MAX_MATURITY = 14 weeks;
     uint16 public constant DEFAULT_DEFAULT_LEVEL = 31;
     uint16 public constant DEFAULT_TILT = 0;
-    uint16 public constant DEFAULT_MODE = 0;
+    uint8 public constant DEFAULT_MODE = 0;
     uint64 public constant DEFAULT_ISSUANCE_FEE = 0.05e18;
     uint256 public constant DEFAULT_GUARD = 100000 * 1e18;
     uint256 public constant DEFAULT_CHAINLINK_ETH_PRICE = 1900 * 1e8; // $1900 per ETH

--- a/pkg/core/src/tests/test-helpers/TestHelper.sol
+++ b/pkg/core/src/tests/test-helpers/TestHelper.sol
@@ -343,7 +343,6 @@ contract TestHelper is DSTest {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
-            rType: Constants.NON_CROP,
             tilt: 0,
             guard: DEFAULT_GUARD
         });
@@ -362,7 +361,6 @@ contract TestHelper is DSTest {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
-            rType: Constants.CROPS,
             tilt: 0,
             guard: DEFAULT_GUARD
         });
@@ -382,7 +380,6 @@ contract TestHelper is DSTest {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
-            rType: Constants.NON_CROP,
             tilt: 0,
             guard: DEFAULT_GUARD
         });
@@ -422,14 +419,12 @@ contract TestHelper is DSTest {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
-            rType: Constants.CROP,
             tilt: 0,
             guard: DEFAULT_GUARD
         });
 
         if (is4626Target) {
             if (crops) {
-                factoryParams.rType = Constants.CROPS;
                 someFactory = address(
                     new ERC4626CropsFactory(address(divider), Constants.REWARDS_RECIPIENT, factoryParams)
                 );
@@ -440,7 +435,6 @@ contract TestHelper is DSTest {
             }
         } else {
             if (crops) {
-                factoryParams.rType = Constants.CROPS;
                 someFactory = address(
                     new MockCropsFactory(address(divider), Constants.REWARDS_RECIPIENT, factoryParams, _rewardTokens)
                 );

--- a/pkg/core/src/tests/test-helpers/TestHelper.sol
+++ b/pkg/core/src/tests/test-helpers/TestHelper.sol
@@ -217,7 +217,6 @@ contract TestHelper is DSTest {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
-            rType: Constants.CROP,
             tilt: 0,
             level: DEFAULT_LEVEL
         });

--- a/pkg/core/src/tests/test-helpers/TestHelper.sol
+++ b/pkg/core/src/tests/test-helpers/TestHelper.sol
@@ -104,7 +104,7 @@ contract TestHelper is DSTest {
     BaseAdapter.AdapterParams public DEFAULT_ADAPTER_PARAMS;
 
     uint256 internal GROWTH_PER_SECOND = 792744799594; // 25% APY
-    uint16 public MODE = 0;
+    uint8 public MODE = 0;
     address public ORACLE = address(123);
     uint64 public ISSUANCE_FEE = 0.05e18;
     uint256 public STAKE_SIZE = 1e18;
@@ -217,6 +217,7 @@ contract TestHelper is DSTest {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
+            rType: Constants.CROP,
             tilt: 0,
             level: DEFAULT_LEVEL
         });
@@ -342,10 +343,11 @@ contract TestHelper is DSTest {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
+            rType: Constants.NON_CROP,
             tilt: 0,
             guard: DEFAULT_GUARD
         });
-        someFactory = address(new ERC4626Factory(address(divider), factoryParams));
+        someFactory = address(new ERC4626Factory(address(divider), Constants.REWARDS_RECIPIENT, factoryParams));
         MockFactory(someFactory).supportTarget(_target, true);
         divider.setIsTrusted(someFactory, true);
         periphery.setFactory(someFactory, true);
@@ -360,10 +362,11 @@ contract TestHelper is DSTest {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
+            rType: Constants.CROPS,
             tilt: 0,
             guard: DEFAULT_GUARD
         });
-        someFactory = address(new ERC4626CropsFactory(address(divider), factoryParams));
+        someFactory = address(new ERC4626CropsFactory(address(divider), Constants.REWARDS_RECIPIENT, factoryParams));
         MockFactory(someFactory).supportTarget(_target, true);
         divider.setIsTrusted(someFactory, true);
         periphery.setFactory(someFactory, true);
@@ -379,13 +382,14 @@ contract TestHelper is DSTest {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
+            rType: Constants.NON_CROP,
             tilt: 0,
             guard: DEFAULT_GUARD
         });
         if (is4626Target) {
-            someFactory = address(new ERC4626Factory(address(divider), factoryParams));
+            someFactory = address(new ERC4626Factory(address(divider), Constants.REWARDS_RECIPIENT, factoryParams));
         } else {
-            someFactory = address(new MockFactory(address(divider), factoryParams));
+            someFactory = address(new MockFactory(address(divider), Constants.REWARDS_RECIPIENT, factoryParams));
         }
         MockFactory(someFactory).supportTarget(_target, true);
         divider.setIsTrusted(someFactory, true);
@@ -418,21 +422,32 @@ contract TestHelper is DSTest {
             minm: MIN_MATURITY,
             maxm: MAX_MATURITY,
             mode: MODE,
+            rType: Constants.CROP,
             tilt: 0,
             guard: DEFAULT_GUARD
         });
 
         if (is4626Target) {
             if (crops) {
-                someFactory = address(new ERC4626CropsFactory(address(divider), factoryParams));
+                factoryParams.rType = Constants.CROPS;
+                someFactory = address(
+                    new ERC4626CropsFactory(address(divider), Constants.REWARDS_RECIPIENT, factoryParams)
+                );
             } else {
-                someFactory = address(new ERC4626CropFactory(address(divider), factoryParams, address(0)));
+                someFactory = address(
+                    new ERC4626CropFactory(address(divider), Constants.REWARDS_RECIPIENT, factoryParams, address(0))
+                );
             }
         } else {
             if (crops) {
-                someFactory = address(new MockCropsFactory(address(divider), factoryParams, _rewardTokens));
+                factoryParams.rType = Constants.CROPS;
+                someFactory = address(
+                    new MockCropsFactory(address(divider), Constants.REWARDS_RECIPIENT, factoryParams, _rewardTokens)
+                );
             } else {
-                someFactory = address(new MockCropFactory(address(divider), factoryParams, _rewardTokens[0]));
+                someFactory = address(
+                    new MockCropFactory(address(divider), Constants.REWARDS_RECIPIENT, factoryParams, _rewardTokens[0])
+                );
             }
         }
         MockFactory(someFactory).supportTarget(_target, true);
@@ -532,6 +547,7 @@ contract TestHelper is DSTest {
                     address(_divider),
                     address(_target),
                     target.underlying(),
+                    Constants.REWARDS_RECIPIENT,
                     ISSUANCE_FEE,
                     DEFAULT_ADAPTER_PARAMS,
                     address(_reward)
@@ -543,6 +559,7 @@ contract TestHelper is DSTest {
                     address(_divider),
                     address(_target),
                     target.asset(),
+                    Constants.REWARDS_RECIPIENT,
                     ISSUANCE_FEE,
                     DEFAULT_ADAPTER_PARAMS,
                     address(_reward)

--- a/pkg/core/src/tests/test-helpers/mocks/MockAdapter.sol
+++ b/pkg/core/src/tests/test-helpers/mocks/MockAdapter.sol
@@ -37,9 +37,10 @@ contract MockAdapter is BaseAdapter {
         address _divider,
         address _target,
         address _underlying,
+        address _rewardsRecipient,
         uint128 _ifee,
         AdapterParams memory _adapterParams
-    ) BaseAdapter(_divider, _target, _underlying, _ifee, _adapterParams) {
+    ) BaseAdapter(_divider, _target, _underlying, _rewardsRecipient, _ifee, _adapterParams) {
         uint256 tDecimals = MockTarget(_target).decimals();
         uint256 uDecimals = MockTarget(_underlying).decimals();
         scalingFactor = 10**(tDecimals > uDecimals ? tDecimals - uDecimals : uDecimals - tDecimals);
@@ -145,10 +146,11 @@ contract MockCropAdapter is BaseAdapter, Crop {
         address _divider,
         address _target,
         address _underlying,
+        address _rewardsRecipient,
         uint128 _ifee,
         AdapterParams memory _adapterParams,
         address _reward
-    ) Crop(_divider, _reward) BaseAdapter(_divider, _target, _underlying, _ifee, _adapterParams) {
+    ) Crop(_divider, _reward) BaseAdapter(_divider, _target, _underlying, _rewardsRecipient, _ifee, _adapterParams) {
         uint256 tDecimals = MockTarget(_target).decimals();
         uint256 uDecimals = MockTarget(_underlying).decimals();
         scalingFactor = 10**(tDecimals > uDecimals ? tDecimals - uDecimals : uDecimals - tDecimals);
@@ -266,10 +268,14 @@ contract MockCropsAdapter is BaseAdapter, Crops {
         address _divider,
         address _target,
         address _underlying,
+        address _rewardsRecipient,
         uint128 _ifee,
         AdapterParams memory _adapterParams,
         address[] memory _rewardTokens
-    ) Crops(_divider, _rewardTokens) BaseAdapter(_divider, _target, _underlying, _ifee, _adapterParams) {
+    )
+        Crops(_divider, _rewardTokens)
+        BaseAdapter(_divider, _target, _underlying, _rewardsRecipient, _ifee, _adapterParams)
+    {
         uint256 tDecimals = MockTarget(_target).decimals();
         uint256 uDecimals = MockTarget(_underlying).decimals();
         scalingFactor = 10**(tDecimals > uDecimals ? tDecimals - uDecimals : uDecimals - tDecimals);
@@ -373,9 +379,10 @@ contract Mock4626Adapter is ERC4626Adapter {
         address _divider,
         address _target,
         address _underlying,
+        address _rewardsRecipient,
         uint128 _ifee,
         AdapterParams memory _adapterParams
-    ) ERC4626Adapter(_divider, _target, _ifee, _adapterParams) {}
+    ) ERC4626Adapter(_divider, _target, _rewardsRecipient, _ifee, _adapterParams) {}
 
     function lscale() external returns (uint256, uint256) {
         return (0, ERC4626(target).convertToAssets(BASE_UINT));
@@ -413,10 +420,11 @@ contract Mock4626CropAdapter is ERC4626Adapter, Crop {
         address _divider,
         address _target,
         address _underlying,
+        address _rewardsRecipient,
         uint128 _ifee,
         AdapterParams memory _adapterParams,
         address _reward
-    ) ERC4626Adapter(_divider, _target, _ifee, _adapterParams) Crop(_divider, _reward) {}
+    ) ERC4626Adapter(_divider, _target, rewardsRecipient, _ifee, _adapterParams) Crop(_divider, _reward) {}
 
     function notify(
         address _usr,
@@ -463,10 +471,11 @@ contract Mock4626CropsAdapter is ERC4626Adapter, Crops {
         address _divider,
         address _target,
         address _underlying,
+        address _rewardsRecipient,
         uint128 _ifee,
         AdapterParams memory _adapterParams,
         address[] memory _rewardTokens
-    ) ERC4626Adapter(_divider, _target, _ifee, _adapterParams) Crops(_divider, _rewardTokens) {
+    ) ERC4626Adapter(_divider, _target, _rewardsRecipient, _ifee, _adapterParams) Crops(_divider, _rewardTokens) {
         uint256 tDecimals = MockTarget(_target).decimals();
         uint256 uDecimals = MockTarget(_underlying).decimals();
         scalingFactor = 10**(tDecimals > uDecimals ? tDecimals - uDecimals : uDecimals - tDecimals);
@@ -508,9 +517,10 @@ contract MockBaseAdapter is BaseAdapter {
         address _divider,
         address _target,
         address _underlying,
+        address _rewardsRecipient,
         uint128 _ifee,
         AdapterParams memory _adapterParams
-    ) BaseAdapter(_divider, _target, _underlying, _ifee, _adapterParams) {}
+    ) BaseAdapter(_divider, _target, _underlying, _rewardsRecipient, _ifee, _adapterParams) {}
 
     function scale() external virtual override returns (uint256 _value) {
         return 100e18;

--- a/pkg/core/src/tests/test-helpers/mocks/MockAdapter.sol
+++ b/pkg/core/src/tests/test-helpers/mocks/MockAdapter.sol
@@ -103,8 +103,9 @@ contract MockAdapter is BaseAdapter {
         // Check that token is neither the target nor the stake
         if (token == target || token == adapterParams.stake) revert Errors.TokenNotSupported();
         ERC20 t = ERC20(token);
-        t.safeTransfer(rewardsRecipient, t.balanceOf(address(this)));
-        emit RewardsClaimed(token, rewardsRecipient);
+        uint256 tBal = t.balanceOf(address(this));
+        t.safeTransfer(rewardsRecipient, tBal);
+        emit RewardsClaimed(token, rewardsRecipient, tBal);
     }
 
     function onRedeem(
@@ -234,8 +235,9 @@ contract MockCropAdapter is BaseAdapter, Crop {
         // Check that token is neither the target, the stake nor the reward
         if (token == target || token == adapterParams.stake || token == reward) revert Errors.TokenNotSupported();
         ERC20 t = ERC20(token);
-        t.safeTransfer(rewardsRecipient, t.balanceOf(address(this)));
-        emit RewardsClaimed(token, rewardsRecipient);
+        uint256 tBal = t.balanceOf(address(this));
+        t.safeTransfer(rewardsRecipient, tBal);
+        emit RewardsClaimed(token, rewardsRecipient, tBal);
     }
 
     function onRedeem(
@@ -375,8 +377,9 @@ contract MockCropsAdapter is BaseAdapter, Crops {
         // Check that token is neither the target nor the stake
         if (token == target || token == adapterParams.stake) revert Errors.TokenNotSupported();
         ERC20 t = ERC20(token);
-        t.safeTransfer(rewardsRecipient, t.balanceOf(address(this)));
-        emit RewardsClaimed(token, rewardsRecipient);
+        uint256 tBal = t.balanceOf(address(this));
+        t.safeTransfer(rewardsRecipient, tBal);
+        emit RewardsClaimed(token, rewardsRecipient, tBal);
     }
 
     function onRedeem(
@@ -479,8 +482,9 @@ contract Mock4626CropAdapter is ERC4626Adapter, Crop {
         // Check that token is neither the target, the stake nor the reward
         if (token == target || token == adapterParams.stake || token == reward) revert Errors.TokenNotSupported();
         ERC20 t = ERC20(token);
-        t.safeTransfer(rewardsRecipient, t.balanceOf(address(this)));
-        emit RewardsClaimed(token, rewardsRecipient);
+        uint256 tBal = t.balanceOf(address(this));
+        t.safeTransfer(rewardsRecipient, tBal);
+        emit RewardsClaimed(token, rewardsRecipient, tBal);
     }
 
     function onRedeem(
@@ -546,8 +550,9 @@ contract Mock4626CropsAdapter is ERC4626Adapter, Crops {
         // Check that token is neither the target nor the stake
         if (token == target || token == adapterParams.stake) revert Errors.TokenNotSupported();
         ERC20 t = ERC20(token);
-        t.safeTransfer(rewardsRecipient, t.balanceOf(address(this)));
-        emit RewardsClaimed(token, rewardsRecipient);
+        uint256 tBal = t.balanceOf(address(this));
+        t.safeTransfer(rewardsRecipient, tBal);
+        emit RewardsClaimed(token, rewardsRecipient, tBal);
     }
 
     function onRedeem(
@@ -609,7 +614,8 @@ contract MockBaseAdapter is BaseAdapter {
         // Check that token is neither the target nor the stake
         if (token == target || token == adapterParams.stake) revert Errors.TokenNotSupported();
         ERC20 t = ERC20(token);
-        t.safeTransfer(rewardsRecipient, t.balanceOf(address(this)));
-        emit RewardsClaimed(token, rewardsRecipient);
+        uint256 tBal = t.balanceOf(address(this));
+        t.safeTransfer(rewardsRecipient, tBal);
+        emit RewardsClaimed(token, rewardsRecipient, tBal);
     }
 }

--- a/pkg/core/src/tests/test-helpers/mocks/MockFactory.sol
+++ b/pkg/core/src/tests/test-helpers/mocks/MockFactory.sol
@@ -50,7 +50,7 @@ contract MockFactory is BaseFactory {
             minm: factoryParams.minm,
             maxm: factoryParams.maxm,
             mode: factoryParams.mode,
-            rType: factoryParams.rType,
+            rType: 0, // Non-crop
             tilt: factoryParams.tilt,
             level: DEFAULT_LEVEL
         });
@@ -100,7 +100,7 @@ contract MockCropFactory is CropFactory {
             minm: factoryParams.minm,
             maxm: factoryParams.maxm,
             mode: factoryParams.mode,
-            rType: factoryParams.rType,
+            rType: 1, // Crop
             tilt: factoryParams.tilt,
             level: DEFAULT_LEVEL
         });
@@ -154,7 +154,7 @@ contract MockCropsFactory is BaseFactory {
             minm: factoryParams.minm,
             maxm: factoryParams.maxm,
             mode: factoryParams.mode,
-            rType: factoryParams.rType,
+            rType: 2, // Crops
             tilt: factoryParams.tilt,
             level: DEFAULT_LEVEL
         });
@@ -208,7 +208,7 @@ contract Mock4626CropFactory is CropFactory {
             minm: factoryParams.minm,
             maxm: factoryParams.maxm,
             mode: factoryParams.mode,
-            rType: factoryParams.rType,
+            rType: 1, // Crop
             tilt: factoryParams.tilt,
             level: DEFAULT_LEVEL
         });
@@ -260,7 +260,7 @@ contract Mock4626CropsFactory is BaseFactory {
             minm: factoryParams.minm,
             maxm: factoryParams.maxm,
             mode: factoryParams.mode,
-            rType: factoryParams.rType,
+            rType: 2, // Crops
             tilt: factoryParams.tilt,
             level: DEFAULT_LEVEL
         });

--- a/pkg/core/src/tests/test-helpers/mocks/MockFactory.sol
+++ b/pkg/core/src/tests/test-helpers/mocks/MockFactory.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.11;
 
 // Internal references
 import { BaseFactory } from "../../../adapters/abstract/factories/BaseFactory.sol";
-import { CropsFactory } from "../../../adapters/abstract/factories/CropsFactory.sol";
 import { CropFactory } from "../../../adapters/abstract/factories/CropFactory.sol";
 import { ERC4626Factory } from "../../../adapters/abstract/factories/ERC4626Factory.sol";
 import { Divider } from "../../../Divider.sol";
@@ -27,7 +26,11 @@ contract MockFactory is BaseFactory {
 
     mapping(address => bool) public targets;
 
-    constructor(address _divider, FactoryParams memory _factoryParams) BaseFactory(_divider, _factoryParams) {}
+    constructor(
+        address _divider,
+        address _rewardsRecipient,
+        BaseFactory.FactoryParams memory _factoryParams
+    ) BaseFactory(_divider, _rewardsRecipient, _factoryParams) {}
 
     function supportTarget(address _target, bool status) external {
         targets[_target] = status;
@@ -47,6 +50,7 @@ contract MockFactory is BaseFactory {
             minm: factoryParams.minm,
             maxm: factoryParams.maxm,
             mode: factoryParams.mode,
+            rType: factoryParams.rType,
             tilt: factoryParams.tilt,
             level: DEFAULT_LEVEL
         });
@@ -56,6 +60,7 @@ contract MockFactory is BaseFactory {
                 divider,
                 _target,
                 MockTargetLike(_target).underlying(),
+                rewardsRecipient,
                 factoryParams.ifee,
                 adapterParams
             )
@@ -72,9 +77,10 @@ contract MockCropFactory is CropFactory {
 
     constructor(
         address _divider,
-        FactoryParams memory _factoryParams,
+        address _rewardsRecipient,
+        BaseFactory.FactoryParams memory _factoryParams,
         address _reward
-    ) CropFactory(_divider, _factoryParams, _reward) {}
+    ) CropFactory(_divider, _rewardsRecipient, _factoryParams, _reward) {}
 
     function supportTarget(address _target, bool status) external {
         targets[_target] = status;
@@ -94,6 +100,7 @@ contract MockCropFactory is CropFactory {
             minm: factoryParams.minm,
             maxm: factoryParams.maxm,
             mode: factoryParams.mode,
+            rType: factoryParams.rType,
             tilt: factoryParams.tilt,
             level: DEFAULT_LEVEL
         });
@@ -103,6 +110,7 @@ contract MockCropFactory is CropFactory {
                 divider,
                 _target,
                 MockTargetLike(_target).underlying(),
+                rewardsRecipient,
                 factoryParams.ifee,
                 adapterParams,
                 reward
@@ -113,7 +121,7 @@ contract MockCropFactory is CropFactory {
     }
 }
 
-contract MockCropsFactory is CropsFactory {
+contract MockCropsFactory is BaseFactory {
     using Bytes32AddressLib for address;
 
     mapping(address => bool) public targets;
@@ -121,9 +129,10 @@ contract MockCropsFactory is CropsFactory {
 
     constructor(
         address _divider,
-        FactoryParams memory _factoryParams,
+        address _rewardsRecipient,
+        BaseFactory.FactoryParams memory _factoryParams,
         address[] memory _rewardTokens
-    ) CropsFactory(_divider, _factoryParams) {
+    ) BaseFactory(_divider, _rewardsRecipient, _factoryParams) {
         rewardTokens = _rewardTokens;
     }
 
@@ -145,6 +154,7 @@ contract MockCropsFactory is CropsFactory {
             minm: factoryParams.minm,
             maxm: factoryParams.maxm,
             mode: factoryParams.mode,
+            rType: factoryParams.rType,
             tilt: factoryParams.tilt,
             level: DEFAULT_LEVEL
         });
@@ -154,6 +164,7 @@ contract MockCropsFactory is CropsFactory {
                 divider,
                 _target,
                 MockTargetLike(_target).underlying(),
+                rewardsRecipient,
                 factoryParams.ifee,
                 adapterParams,
                 rewardTokens
@@ -174,9 +185,10 @@ contract Mock4626CropFactory is CropFactory {
 
     constructor(
         address _divider,
-        FactoryParams memory _factoryParams,
+        address _rewardsRecipient,
+        BaseFactory.FactoryParams memory _factoryParams,
         address _reward
-    ) CropFactory(_divider, _factoryParams, _reward) {}
+    ) CropFactory(_divider, _rewardsRecipient, _factoryParams, _reward) {}
 
     function supportTarget(address _target, bool status) external {
         targets[_target] = status;
@@ -196,6 +208,7 @@ contract Mock4626CropFactory is CropFactory {
             minm: factoryParams.minm,
             maxm: factoryParams.maxm,
             mode: factoryParams.mode,
+            rType: factoryParams.rType,
             tilt: factoryParams.tilt,
             level: DEFAULT_LEVEL
         });
@@ -205,6 +218,7 @@ contract Mock4626CropFactory is CropFactory {
                 divider,
                 _target,
                 MockTargetLike(_target).asset(),
+                rewardsRecipient,
                 factoryParams.ifee,
                 adapterParams,
                 reward
@@ -213,7 +227,7 @@ contract Mock4626CropFactory is CropFactory {
     }
 }
 
-contract Mock4626CropsFactory is CropsFactory {
+contract Mock4626CropsFactory is BaseFactory {
     using Bytes32AddressLib for address;
 
     mapping(address => bool) public targets;
@@ -221,9 +235,10 @@ contract Mock4626CropsFactory is CropsFactory {
 
     constructor(
         address _divider,
-        FactoryParams memory _factoryParams,
+        address _rewardsRecipient,
+        BaseFactory.FactoryParams memory _factoryParams,
         address[] memory _rewardTokens
-    ) CropsFactory(_divider, _factoryParams) {
+    ) BaseFactory(_divider, _rewardsRecipient, _factoryParams) {
         rewardTokens = _rewardTokens;
     }
 
@@ -245,6 +260,7 @@ contract Mock4626CropsFactory is CropsFactory {
             minm: factoryParams.minm,
             maxm: factoryParams.maxm,
             mode: factoryParams.mode,
+            rType: factoryParams.rType,
             tilt: factoryParams.tilt,
             level: DEFAULT_LEVEL
         });
@@ -254,6 +270,7 @@ contract Mock4626CropsFactory is CropsFactory {
                 divider,
                 _target,
                 MockTargetLike(_target).asset(),
+                rewardsRecipient,
                 factoryParams.ifee,
                 adapterParams,
                 rewardTokens

--- a/pkg/core/src/tests/test-helpers/mocks/MockFactory.sol
+++ b/pkg/core/src/tests/test-helpers/mocks/MockFactory.sol
@@ -50,7 +50,6 @@ contract MockFactory is BaseFactory {
             minm: factoryParams.minm,
             maxm: factoryParams.maxm,
             mode: factoryParams.mode,
-            rType: 0, // Non-crop
             tilt: factoryParams.tilt,
             level: DEFAULT_LEVEL
         });
@@ -100,7 +99,6 @@ contract MockCropFactory is CropFactory {
             minm: factoryParams.minm,
             maxm: factoryParams.maxm,
             mode: factoryParams.mode,
-            rType: 1, // Crop
             tilt: factoryParams.tilt,
             level: DEFAULT_LEVEL
         });
@@ -154,7 +152,6 @@ contract MockCropsFactory is BaseFactory {
             minm: factoryParams.minm,
             maxm: factoryParams.maxm,
             mode: factoryParams.mode,
-            rType: 2, // Crops
             tilt: factoryParams.tilt,
             level: DEFAULT_LEVEL
         });
@@ -208,7 +205,6 @@ contract Mock4626CropFactory is CropFactory {
             minm: factoryParams.minm,
             maxm: factoryParams.maxm,
             mode: factoryParams.mode,
-            rType: 1, // Crop
             tilt: factoryParams.tilt,
             level: DEFAULT_LEVEL
         });
@@ -260,7 +256,6 @@ contract Mock4626CropsFactory is BaseFactory {
             minm: factoryParams.minm,
             maxm: factoryParams.maxm,
             mode: factoryParams.mode,
-            rType: 2, // Crops
             tilt: factoryParams.tilt,
             level: DEFAULT_LEVEL
         });

--- a/pkg/deployments/deploy/prod/04-factories.js
+++ b/pkg/deployments/deploy/prod/04-factories.js
@@ -34,11 +34,11 @@ module.exports = async function () {
       targets,
       guard,
     } = factory(chainId);
-    if ([CROP, CROPS].includes(rType) && !reward) throw Error("No reward token found");
+    if (rType == CROP && !reward) throw Error("No reward token found");
     if (!stake) throw Error("No stake token found");
 
     log(`\nDeploy ${contractName}`);
-    const factoryParams = [oracle, stake, stakeSize, minm, maxm, ifee, mode, rType, tilt, guard];
+    const factoryParams = [oracle, stake, stakeSize, minm, maxm, ifee, mode, tilt, guard];
     const { address: factoryAddress } = await deploy(contractName, {
       from: deployer,
       args: [divider.address, rewardsRecipient, factoryParams, ...(rType !== CROPS ? [reward] : [])],

--- a/pkg/deployments/deploy/prod/04-factories.js
+++ b/pkg/deployments/deploy/prod/04-factories.js
@@ -1,4 +1,6 @@
 const { network } = require("hardhat");
+const { SENSE_MULTISIG } = require("../../hardhat.addresses");
+const { CROP, CROPS } = require("../../hardhat.seed");
 const { moveDeployments, writeDeploymentsToFile, writeAdaptersToFile } = require("../../hardhat.utils");
 const log = console.log;
 
@@ -10,6 +12,7 @@ module.exports = async function () {
   const chainId = await getChainId();
   const divider = await ethers.getContract("Divider", signer);
   const periphery = await ethers.getContract("Periphery", signer);
+  const rewardsRecipient = SENSE_MULTISIG.get(chainId);
 
   log("\n-------------------------------------------------------");
   log("DEPLOY FACTORIES & ADAPTERS");
@@ -25,20 +28,20 @@ module.exports = async function () {
       maxm,
       ifee,
       mode,
+      rType,
       tilt,
       reward,
       targets,
-      crops,
       guard,
     } = factory(chainId);
-    if (!crops && !reward) throw Error("No reward token found");
+    if ([CROP, CROPS].includes(rType) && !reward) throw Error("No reward token found");
     if (!stake) throw Error("No stake token found");
 
     log(`\nDeploy ${contractName}`);
-    const factoryParams = [oracle, stake, stakeSize, minm, maxm, ifee, mode, tilt, guard];
+    const factoryParams = [oracle, stake, stakeSize, minm, maxm, ifee, mode, rType, tilt, guard];
     const { address: factoryAddress } = await deploy(contractName, {
       from: deployer,
-      args: [divider.address, factoryParams, ...(!crops ? [reward] : [])],
+      args: [divider.address, rewardsRecipient, factoryParams, ...(rType !== CROPS ? [reward] : [])],
       log: true,
     });
 
@@ -86,6 +89,7 @@ module.exports = async function () {
         divider.address,
         tAddress,
         ...(underlying ? [underlying] : []),
+        rewardsRecipient,
         ifee,
         ...(comptroller ? [comptroller] : []),
         adapterParams,

--- a/pkg/deployments/deploy/simulated/04-adapters.js
+++ b/pkg/deployments/deploy/simulated/04-adapters.js
@@ -50,7 +50,7 @@ module.exports = async function () {
     } = factory(chainId);
     log(`\nDeploy ${factoryContractName} with mocked dependencies`);
     // Large enough to not be a problem, but won't overflow on ModAdapter.fmul
-    const factoryParams = [oracle, stake.address, stakeSize, minm, maxm, ifee, mode, rType, tilt, guard];
+    const factoryParams = [oracle, stake.address, stakeSize, minm, maxm, ifee, mode, tilt, guard];
     const { address: mockFactoryAddress } = await deploy(factoryContractName, {
       from: deployer,
       args: [
@@ -293,7 +293,7 @@ module.exports = async function () {
   }
 
   async function deployAdapterWithoutFactory(t, targetContract) {
-    let { contractName, adapterParams, target, underlying, ifee } = t;
+    let { contractName, adapterParams, target, underlying, ifee, rType } = t;
     const targetAddress = targetContract.address;
     underlying = await targetContract.underlying();
     adapterParams.stake = stake.address;
@@ -308,11 +308,7 @@ module.exports = async function () {
         rewardsRecipient,
         ifee,
         adapterParams,
-        ...(adapterParams.rType == NON_CROP
-          ? []
-          : adapterParams.rType == CROPS
-          ? [[airdrop.address]]
-          : [airdrop.address]),
+        ...(rType == NON_CROP ? [] : rType == CROPS ? [[airdrop.address]] : [airdrop.address]),
       ],
       log: true,
     });

--- a/pkg/deployments/hardhat.seed.js
+++ b/pkg/deployments/hardhat.seed.js
@@ -187,6 +187,7 @@ const DEV_ADAPTERS = [
     },
     underlying: "0x0",
     ifee: ethers.utils.parseEther("0.01"),
+    rType: NON_CROP,
     adapterParams: {
       oracle: ethers.constants.AddressZero, // oracle address
       ifee: ethers.utils.parseEther("0.01"),
@@ -195,7 +196,6 @@ const DEV_ADAPTERS = [
       minm: "0", // 0 weeks
       maxm: "4838400", // 4 weeks
       mode: 1, // 0 monthly, 1 weekly;
-      rType: NON_CROP,
       tilt: 0,
       level: 31,
     },
@@ -211,6 +211,7 @@ const DEV_ADAPTERS = [
     },
     underlying: "0x0",
     ifee: ethers.utils.parseEther("0.01"),
+    rType: CROP,
     adapterParams: {
       oracle: ethers.constants.AddressZero, // oracle address
       ifee: ethers.utils.parseEther("0.01"),
@@ -219,7 +220,6 @@ const DEV_ADAPTERS = [
       minm: "0", // 0 weeks
       maxm: "4838400", // 4 weeks
       mode: 1, // 0 monthly, 1 weekly;
-      rType: CROP,
       tilt: 0,
       level: 31,
     },
@@ -235,6 +235,7 @@ const DEV_ADAPTERS = [
     },
     underlying: "0x0",
     ifee: ethers.utils.parseEther("0.01"),
+    rType: CROPS,
     adapterParams: {
       oracle: ethers.constants.AddressZero, // oracle address
       stake: "0x0",
@@ -242,7 +243,6 @@ const DEV_ADAPTERS = [
       minm: "0", // 0 weeks
       maxm: "4838400", // 4 weeks
       mode: 1, // 0 monthly, 1 weekly;
-      rType: CROPS,
       tilt: 0,
       level: 31,
     },
@@ -408,6 +408,7 @@ const MAINNET_ADAPTERS = [
       series: CUSDC_WSTETH_SERIES_MATURITIES,
     },
     ifee: ethers.utils.parseEther("0.01"),
+    rType: NON_CROP,
     adapterParams: {
       oracle: MASTER_ORACLE.get(chainId), // oracle address
       stake: WETH_TOKEN.get(chainId),
@@ -415,7 +416,6 @@ const MAINNET_ADAPTERS = [
       minm: "0", // 0 weeks
       maxm: "604800", // 1 week
       mode: 1, // 0 monthly, 1 weekly;
-      rType: NON_CROP,
       tilt: 0,
       level: 31,
     },
@@ -434,6 +434,7 @@ const MAINNET_ADAPTERS = [
     },
     underlying: FRAX3CRV_TOKEN.get(chainId),
     ifee: ethers.utils.parseEther("0.01"),
+    rType: CROPS,
     adapterParams: {
       oracle: MASTER_ORACLE.get(chainId), // oracle address
       stake: WETH_TOKEN.get(chainId),
@@ -441,7 +442,6 @@ const MAINNET_ADAPTERS = [
       minm: "0", // 0 weeks
       maxm: "604800", // 1 week
       mode: 1, // 0 monthly, 1 weekly;
-      rType: CROPS,
       tilt: 0,
       level: 31,
     },

--- a/pkg/fuse/src/tests/NoopPoolManager.tm.sol
+++ b/pkg/fuse/src/tests/NoopPoolManager.tm.sol
@@ -83,7 +83,6 @@ contract NoopPoolManagerTest is DSTest {
             minm: 2 weeks,
             maxm: 14 weeks,
             mode: 0,
-            rType: Constants.NON_CROP,
             tilt: 0,
             level: 31
         });

--- a/pkg/fuse/src/tests/NoopPoolManager.tm.sol
+++ b/pkg/fuse/src/tests/NoopPoolManager.tm.sol
@@ -95,10 +95,11 @@ contract NoopPoolManagerTest is DSTest {
             minm: 2 weeks,
             maxm: 14 weeks,
             mode: 0,
+            rType: Constants.NON_CROP,
             tilt: 0,
             guard: 1e18
         });
-        mockFactory = new MockFactory(address(divider), factoryParams);
+        mockFactory = new MockFactory(address(divider), Constants.REWARDS_RECIPIENT, factoryParams);
 
         // Ping scale to set an lscale
         mockAdapter.scale();

--- a/pkg/fuse/src/tests/NoopPoolManager.tm.sol
+++ b/pkg/fuse/src/tests/NoopPoolManager.tm.sol
@@ -104,7 +104,6 @@ contract NoopPoolManagerTest is DSTest {
             minm: 2 weeks,
             maxm: 14 weeks,
             mode: 0,
-            rType: Constants.NON_CROP,
             tilt: 0,
             guard: 1e18
         });

--- a/pkg/fuse/src/tests/NoopPoolManager.tm.sol
+++ b/pkg/fuse/src/tests/NoopPoolManager.tm.sol
@@ -21,6 +21,7 @@ import { Hevm } from "@sense-finance/v1-core/src/tests/test-helpers/Hevm.sol";
 import { DateTimeFull } from "@sense-finance/v1-core/src/tests/test-helpers/DateTimeFull.sol";
 import { AddressBook } from "@sense-finance/v1-core/src/tests/test-helpers/AddressBook.sol";
 import { MockBalancerVault, MockSpaceFactory, MockSpacePool } from "@sense-finance/v1-core/src/tests/test-helpers/mocks/MockSpace.sol";
+import { Constants } from "@sense-finance/v1-core/src/tests/test-helpers/Constants.sol";
 
 contract NoopPoolManagerTest is DSTest {
     using FixedMath for uint256;
@@ -82,10 +83,18 @@ contract NoopPoolManagerTest is DSTest {
             minm: 2 weeks,
             maxm: 14 weeks,
             mode: 0,
+            rType: Constants.NON_CROP,
             tilt: 0,
             level: 31
         });
-        mockAdapter = new MockAdapter(address(divider), address(target), target.underlying(), 0.1e18, adapterParams);
+        mockAdapter = new MockAdapter(
+            address(divider),
+            address(target),
+            target.underlying(),
+            Constants.REWARDS_RECIPIENT,
+            0.1e18,
+            adapterParams
+        );
 
         BaseFactory.FactoryParams memory factoryParams = BaseFactory.FactoryParams({
             stake: address(stake),
@@ -157,6 +166,7 @@ contract NoopPoolManagerTest is DSTest {
             address(divider),
             address(target),
             target.underlying(),
+            Constants.REWARDS_RECIPIENT,
             0.1e18,
             adapterParams
         );
@@ -166,6 +176,7 @@ contract NoopPoolManagerTest is DSTest {
             address(divider),
             address(target),
             target.underlying(),
+            Constants.REWARDS_RECIPIENT,
             0.1e18,
             adapterParams
         );
@@ -176,6 +187,7 @@ contract NoopPoolManagerTest is DSTest {
             address(divider),
             address(target),
             target.underlying(),
+            Constants.REWARDS_RECIPIENT,
             0.1e18,
             adapterParams
         );
@@ -192,6 +204,7 @@ contract NoopPoolManagerTest is DSTest {
             address(divider),
             address(target),
             target.underlying(),
+            Constants.REWARDS_RECIPIENT,
             0.1e18,
             adapterParams
         );

--- a/pkg/fuse/src/tests/PoolManager.tm.sol
+++ b/pkg/fuse/src/tests/PoolManager.tm.sol
@@ -20,6 +20,7 @@ import { MockAdapter } from "@sense-finance/v1-core/src/tests/test-helpers/mocks
 import { Hevm } from "@sense-finance/v1-core/src/tests/test-helpers/Hevm.sol";
 import { DateTimeFull } from "@sense-finance/v1-core/src/tests/test-helpers/DateTimeFull.sol";
 import { AddressBook } from "@sense-finance/v1-core/src/tests/test-helpers/AddressBook.sol";
+import { Constants } from "@sense-finance/v1-core/src/tests/test-helpers/Constants.sol";
 import { MockBalancerVault, MockSpaceFactory, MockSpacePool } from "@sense-finance/v1-core/src/tests/test-helpers/mocks/MockSpace.sol";
 import { PriceOracle } from "../external/PriceOracle.sol";
 
@@ -87,10 +88,18 @@ contract PoolManagerTest is DSTest {
             minm: 2 weeks,
             maxm: 14 weeks,
             mode: 0,
+            rType: Constants.NON_CROP,
             tilt: 0,
             level: 31
         });
-        mockAdapter = new MockAdapter(address(divider), address(target), target.underlying(), 0.1e18, adapterParams);
+        mockAdapter = new MockAdapter(
+            address(divider),
+            address(target),
+            target.underlying(),
+            Constants.REWARDS_RECIPIENT,
+            0.1e18,
+            adapterParams
+        );
 
         // Ping scale to set an lscale
         mockAdapter.scale();

--- a/pkg/fuse/src/tests/PoolManager.tm.sol
+++ b/pkg/fuse/src/tests/PoolManager.tm.sol
@@ -88,7 +88,6 @@ contract PoolManagerTest is DSTest {
             minm: 2 weeks,
             maxm: 14 weeks,
             mode: 0,
-            rType: Constants.NON_CROP,
             tilt: 0,
             level: 31
         });


### PR DESCRIPTION
## Motivation

Even though we have Crop and Crops solutions to handle airdropped or claimed reward tokens, it is hard to predict all the different mechanism protocols create to distribute their reward tokens.

Because of this, we need to provide a method that would allow a trusted address to extract an arbitrary token from it. 

## Solution

- Create an `extractToken` function that transfers all the adapter's balance for a given token (which can NOT be the stake, target nor a reward token in case of Crop(s)) to the `rewardsRecipient` address
- Provide a method to update the `rewardsRecipient` address


## Implementer Checklist

<!--
Fill out the checklist below as applicable to your change. Bug fixes and new features must 
check off all of the required items.
-->


- [ ]  [FIRST TIME ONLY] Review the [Solcurity](https://github.com/Rari-Capital/solcurity) standard
- [x]  [OPTIONAL] Create a reference implementation (in python or JS)
- [x]  Create a short "Motivation" section for the PR
- [x]  Write a spec for the feature and put it in the PR description – basic function names and expected state transitions is OK
- [x]  Check all of the new revert paths with concrete tests
- [x]  Check all of the new storage slot writes with concrete tests – do not make the passing test case the trivial case!
- [x]  Go line-by-line through the new code and ensure it has all been covered by concrete tests – since we don’t have a coverage engine for foundry yet, you can imagine how one might check that each different code path is covered
- [ ]  Simplify the implementation and spend some time trying to minimize gas costs
- [ ]  Write fuzz tests for the feature – try everything to break the implementation (is this function monotonically in/decreasing, should it always be less than something else, etc)
- [ ]  Capture bugs discovered during the above steps in concrete tests (regression tests)
- [ ]  Add integration tests – fuzz or concrete tests that test how the new code affects the entire system, either locally or with a mainnet fork
- [ ]  [OPTIONAL] Integrate the feature into the deployment scripts
- [ ]  [OPTIONAL] Add new sanity checks to the deployment scripts
- [ ]  Get the PR reviewed by at least two people