### PR TITLE
GEN-1566: fix redeem restriction

### DIFF
--- a/pkg/core/src/Divider.sol
+++ b/pkg/core/src/Divider.sol
@@ -311,7 +311,7 @@ contract Divider is Trust, ReentrancyGuard, Pausable {
         if (!_settled(adapter, maturity)) revert Errors.NotSettled();
 
         uint256 level = adapterMeta[adapter].level;
-        if (level.redeemRestricted() && msg.sender == adapter) revert Errors.RedeemRestricted();
+        if (level.redeemRestricted() && msg.sender != adapter) revert Errors.RedeemRestricted();
 
         // Burn the caller's PT
         Token(series[adapter][maturity].pt).burn(msg.sender, uBal);

--- a/pkg/core/src/tests/Divider.t.sol
+++ b/pkg/core/src/tests/Divider.t.sol
@@ -486,11 +486,11 @@ contract Dividers is TestHelper {
         // Can issue through adapter
         target.transfer(address(adapter), 1e18);
 
-        hevm.startPrank(address(adapter));
+        vm.startPrank(address(adapter));
         divider.issue(address(adapter), maturity, 1e18);
         ERC20(pt).transfer(bob, ERC20(pt).balanceOf(address(adapter)));
         ERC20(yt).transfer(bob, ERC20(yt).balanceOf(address(adapter)));
-        hevm.stopPrank();
+        vm.stopPrank();
 
         // It should still be possible to combine
         uint256 ytBal = ERC20(yt).balanceOf(bob);
@@ -516,22 +516,22 @@ contract Dividers is TestHelper {
         divider.issue(address(adapter), maturity, 1e18);
 
         // Issue PTs and YTs from adapter (to test redeeming from adapter)
-        hevm.prank(address(adapter));
+        vm.prank(address(adapter));
         divider.issue(address(adapter), maturity, 1e18);
 
         // Move to maturity and settle
-        hevm.warp(maturity);
+        vm.warp(maturity);
         divider.settleSeries(address(adapter), maturity);
 
         uint256 uBal = ERC20(pt).balanceOf(address(this));
 
         // Can't redeem directly through the divider
-        hevm.expectRevert(abi.encodeWithSelector(Errors.RedeemRestricted.selector));
+        vm.expectRevert(abi.encodeWithSelector(Errors.RedeemRestricted.selector));
         divider.redeem(address(adapter), maturity, uBal);
 
         // Can redeem through adapter
         uint256 tBalBefore = target.balanceOf(address(adapter));
-        hevm.prank(address(adapter));
+        vm.prank(address(adapter));
         divider.redeem(address(adapter), maturity, uBal);
 
         // User should still have their PTs (because they were not burnt)

--- a/pkg/core/src/tests/Divider.t.sol
+++ b/pkg/core/src/tests/Divider.t.sol
@@ -515,7 +515,7 @@ contract Dividers is TestHelper {
         // Issue PTs andn YTs from user
         divider.issue(address(adapter), maturity, 1e18);
 
-        // Issue PTs andn YTs from adapter (to test redeeming from adapter)
+        // Issue PTs and YTs from adapter (to test redeeming from adapter)
         hevm.prank(address(adapter));
         divider.issue(address(adapter), maturity, 1e18);
 
@@ -525,7 +525,7 @@ contract Dividers is TestHelper {
 
         uint256 uBal = ERC20(pt).balanceOf(address(this));
 
-        // Can't issue directly through the divider
+        // Can't redeem directly through the divider
         hevm.expectRevert(abi.encodeWithSelector(Errors.RedeemRestricted.selector));
         divider.redeem(address(adapter), maturity, uBal);
 

--- a/pkg/core/src/tests/test-helpers/mocks/MockAdapter.sol
+++ b/pkg/core/src/tests/test-helpers/mocks/MockAdapter.sol
@@ -125,6 +125,13 @@ contract MockAdapter is BaseAdapter, ExtractableReward {
         MockToken(yt).transfer(msg.sender, MockToken(yt).balanceOf(address(this)));
     }
 
+    function doRedeem(uint256 maturity, uint256 ptBal) external {
+        (address pt, , address yt, , , , , , ) = Divider(divider).series(address(this), maturity);
+        ERC20(pt).transferFrom(msg.sender, address(this), ptBal);
+        Divider(divider).redeem(address(this), maturity, ptBal);
+        MockTarget(target).transfer(msg.sender, MockTarget(target).balanceOf(address(this)));
+    }
+
     function doCombine(uint256 maturity, uint256 uBal) external returns (uint256 tBal) {
         tBal = Divider(divider).combine(address(this), maturity, uBal);
     }
@@ -254,6 +261,13 @@ contract MockCropAdapter is BaseAdapter, Crop, ExtractableReward {
         (address pt, , address yt, , , , , , ) = Divider(divider).series(address(this), maturity);
         MockToken(pt).transfer(msg.sender, MockToken(pt).balanceOf(address(this)));
         MockToken(yt).transfer(msg.sender, MockToken(yt).balanceOf(address(this)));
+    }
+
+    function doRedeem(uint256 maturity, uint256 ptBal) external {
+        (address pt, , , , , , , , ) = Divider(divider).series(address(this), maturity);
+        ERC20(pt).transferFrom(msg.sender, address(this), ptBal);
+        Divider(divider).redeem(address(this), maturity, ptBal);
+        MockTarget(target).transfer(msg.sender, MockTarget(target).balanceOf(address(this)));
     }
 
     function doCombine(uint256 maturity, uint256 uBal) external returns (uint256 tBal) {
@@ -395,6 +409,13 @@ contract MockCropsAdapter is BaseAdapter, Crops, ExtractableReward {
         MockToken(yt).transfer(msg.sender, MockToken(yt).balanceOf(address(this)));
     }
 
+    function doRedeem(uint256 maturity, uint256 ptBal) external {
+        (address pt, , address yt, , , , , , ) = Divider(divider).series(address(this), maturity);
+        ERC20(pt).transferFrom(msg.sender, address(this), ptBal);
+        Divider(divider).redeem(address(this), maturity, ptBal);
+        MockTarget(target).transfer(msg.sender, MockTarget(target).balanceOf(address(this)));
+    }
+
     function doCombine(uint256 maturity, uint256 uBal) external returns (uint256 tBal) {
         tBal = Divider(divider).combine(address(this), maturity, uBal);
     }
@@ -434,6 +455,13 @@ contract Mock4626Adapter is ERC4626Adapter {
         (address pt, , address yt, , , , , , ) = Divider(divider).series(address(this), maturity);
         MockToken(pt).transfer(msg.sender, MockToken(pt).balanceOf(address(this)));
         MockToken(yt).transfer(msg.sender, MockToken(yt).balanceOf(address(this)));
+    }
+
+    function doRedeem(uint256 maturity, uint256 ptBal) external {
+        (address pt, , address yt, , , , , , ) = Divider(divider).series(address(this), maturity);
+        ERC20(pt).transferFrom(msg.sender, address(this), ptBal);
+        Divider(divider).redeem(address(this), maturity, ptBal);
+        MockTarget(target).transfer(msg.sender, MockTarget(target).balanceOf(address(this)));
     }
 
     function doCombine(uint256 maturity, uint256 uBal) external returns (uint256 tBal) {
@@ -489,6 +517,13 @@ contract Mock4626CropAdapter is ERC4626Adapter, Crop {
         (address pt, , address yt, , , , , , ) = Divider(divider).series(address(this), maturity);
         MockToken(pt).transfer(msg.sender, MockToken(pt).balanceOf(address(this)));
         MockToken(yt).transfer(msg.sender, MockToken(yt).balanceOf(address(this)));
+    }
+
+    function doRedeem(uint256 maturity, uint256 ptBal) external {
+        (address pt, , address yt, , , , , , ) = Divider(divider).series(address(this), maturity);
+        ERC20(pt).transferFrom(msg.sender, address(this), ptBal);
+        Divider(divider).redeem(address(this), maturity, ptBal);
+        MockTarget(target).transfer(msg.sender, MockTarget(target).balanceOf(address(this)));
     }
 
     function doCombine(uint256 maturity, uint256 uBal) external returns (uint256 tBal) {
@@ -553,6 +588,13 @@ contract Mock4626CropsAdapter is ERC4626Adapter, Crops {
         (address pt, , address yt, , , , , , ) = Divider(divider).series(address(this), maturity);
         MockToken(pt).transfer(msg.sender, MockToken(pt).balanceOf(address(this)));
         MockToken(yt).transfer(msg.sender, MockToken(yt).balanceOf(address(this)));
+    }
+
+    function doRedeem(uint256 maturity, uint256 ptBal) external {
+        (address pt, , address yt, , , , , , ) = Divider(divider).series(address(this), maturity);
+        ERC20(pt).transferFrom(msg.sender, address(this), ptBal);
+        Divider(divider).redeem(address(this), maturity, ptBal);
+        MockTarget(target).transfer(msg.sender, MockTarget(target).balanceOf(address(this)));
     }
 
     function doCombine(uint256 maturity, uint256 uBal) external returns (uint256 tBal) {

--- a/pkg/core/src/tests/test-helpers/mocks/MockAdapter.sol
+++ b/pkg/core/src/tests/test-helpers/mocks/MockAdapter.sol
@@ -116,25 +116,6 @@ contract MockAdapter is BaseAdapter, ExtractableReward {
     function setScale(uint256 _scaleOverride) external {
         scaleOverride = _scaleOverride;
     }
-
-    function doIssue(uint256 maturity, uint256 tBal) external {
-        MockTarget(target).transferFrom(msg.sender, address(this), tBal);
-        Divider(divider).issue(address(this), maturity, tBal);
-        (address pt, , address yt, , , , , , ) = Divider(divider).series(address(this), maturity);
-        MockToken(pt).transfer(msg.sender, MockToken(pt).balanceOf(address(this)));
-        MockToken(yt).transfer(msg.sender, MockToken(yt).balanceOf(address(this)));
-    }
-
-    function doRedeem(uint256 maturity, uint256 ptBal) external {
-        (address pt, , address yt, , , , , , ) = Divider(divider).series(address(this), maturity);
-        ERC20(pt).transferFrom(msg.sender, address(this), ptBal);
-        Divider(divider).redeem(address(this), maturity, ptBal);
-        MockTarget(target).transfer(msg.sender, MockTarget(target).balanceOf(address(this)));
-    }
-
-    function doCombine(uint256 maturity, uint256 uBal) external returns (uint256 tBal) {
-        tBal = Divider(divider).combine(address(this), maturity, uBal);
-    }
 }
 
 // Mock crop adapter
@@ -253,25 +234,6 @@ contract MockCropAdapter is BaseAdapter, Crop, ExtractableReward {
 
     function setScale(uint256 _scaleOverride) external {
         scaleOverride = _scaleOverride;
-    }
-
-    function doIssue(uint256 maturity, uint256 tBal) external {
-        MockTarget(target).transferFrom(msg.sender, address(this), tBal);
-        Divider(divider).issue(address(this), maturity, tBal);
-        (address pt, , address yt, , , , , , ) = Divider(divider).series(address(this), maturity);
-        MockToken(pt).transfer(msg.sender, MockToken(pt).balanceOf(address(this)));
-        MockToken(yt).transfer(msg.sender, MockToken(yt).balanceOf(address(this)));
-    }
-
-    function doRedeem(uint256 maturity, uint256 ptBal) external {
-        (address pt, , , , , , , , ) = Divider(divider).series(address(this), maturity);
-        ERC20(pt).transferFrom(msg.sender, address(this), ptBal);
-        Divider(divider).redeem(address(this), maturity, ptBal);
-        MockTarget(target).transfer(msg.sender, MockTarget(target).balanceOf(address(this)));
-    }
-
-    function doCombine(uint256 maturity, uint256 uBal) external returns (uint256 tBal) {
-        tBal = Divider(divider).combine(address(this), maturity, uBal);
     }
 }
 
@@ -400,25 +362,6 @@ contract MockCropsAdapter is BaseAdapter, Crops, ExtractableReward {
     function setScale(uint256 _scaleOverride) external {
         scaleOverride = _scaleOverride;
     }
-
-    function doIssue(uint256 maturity, uint256 tBal) external {
-        MockTarget(target).transferFrom(msg.sender, address(this), tBal);
-        Divider(divider).issue(address(this), maturity, tBal);
-        (address pt, , address yt, , , , , , ) = Divider(divider).series(address(this), maturity);
-        MockToken(pt).transfer(msg.sender, MockToken(pt).balanceOf(address(this)));
-        MockToken(yt).transfer(msg.sender, MockToken(yt).balanceOf(address(this)));
-    }
-
-    function doRedeem(uint256 maturity, uint256 ptBal) external {
-        (address pt, , address yt, , , , , , ) = Divider(divider).series(address(this), maturity);
-        ERC20(pt).transferFrom(msg.sender, address(this), ptBal);
-        Divider(divider).redeem(address(this), maturity, ptBal);
-        MockTarget(target).transfer(msg.sender, MockTarget(target).balanceOf(address(this)));
-    }
-
-    function doCombine(uint256 maturity, uint256 uBal) external returns (uint256 tBal) {
-        tBal = Divider(divider).combine(address(this), maturity, uBal);
-    }
 }
 
 // Mock ERC4626 crop adapter
@@ -447,25 +390,6 @@ contract Mock4626Adapter is ERC4626Adapter {
         uint256 /* tBal */
     ) public virtual override {
         onRedeemCalls++;
-    }
-
-    function doIssue(uint256 maturity, uint256 tBal) external {
-        MockTarget(target).transferFrom(msg.sender, address(this), tBal);
-        Divider(divider).issue(address(this), maturity, tBal);
-        (address pt, , address yt, , , , , , ) = Divider(divider).series(address(this), maturity);
-        MockToken(pt).transfer(msg.sender, MockToken(pt).balanceOf(address(this)));
-        MockToken(yt).transfer(msg.sender, MockToken(yt).balanceOf(address(this)));
-    }
-
-    function doRedeem(uint256 maturity, uint256 ptBal) external {
-        (address pt, , address yt, , , , , , ) = Divider(divider).series(address(this), maturity);
-        ERC20(pt).transferFrom(msg.sender, address(this), ptBal);
-        Divider(divider).redeem(address(this), maturity, ptBal);
-        MockTarget(target).transfer(msg.sender, MockTarget(target).balanceOf(address(this)));
-    }
-
-    function doCombine(uint256 maturity, uint256 uBal) external returns (uint256 tBal) {
-        tBal = Divider(divider).combine(address(this), maturity, uBal);
     }
 }
 
@@ -509,25 +433,6 @@ contract Mock4626CropAdapter is ERC4626Adapter, Crop {
         uint256 /* tBal */
     ) public virtual override {
         onRedeemCalls++;
-    }
-
-    function doIssue(uint256 maturity, uint256 tBal) external {
-        MockTarget(target).transferFrom(msg.sender, address(this), tBal);
-        Divider(divider).issue(address(this), maturity, tBal);
-        (address pt, , address yt, , , , , , ) = Divider(divider).series(address(this), maturity);
-        MockToken(pt).transfer(msg.sender, MockToken(pt).balanceOf(address(this)));
-        MockToken(yt).transfer(msg.sender, MockToken(yt).balanceOf(address(this)));
-    }
-
-    function doRedeem(uint256 maturity, uint256 ptBal) external {
-        (address pt, , address yt, , , , , , ) = Divider(divider).series(address(this), maturity);
-        ERC20(pt).transferFrom(msg.sender, address(this), ptBal);
-        Divider(divider).redeem(address(this), maturity, ptBal);
-        MockTarget(target).transfer(msg.sender, MockTarget(target).balanceOf(address(this)));
-    }
-
-    function doCombine(uint256 maturity, uint256 uBal) external returns (uint256 tBal) {
-        tBal = Divider(divider).combine(address(this), maturity, uBal);
     }
 }
 
@@ -580,25 +485,6 @@ contract Mock4626CropsAdapter is ERC4626Adapter, Crops {
         uint256 /* tBal */
     ) public virtual override {
         onRedeemCalls++;
-    }
-
-    function doIssue(uint256 maturity, uint256 tBal) external {
-        MockTarget(target).transferFrom(msg.sender, address(this), tBal);
-        Divider(divider).issue(address(this), maturity, tBal);
-        (address pt, , address yt, , , , , , ) = Divider(divider).series(address(this), maturity);
-        MockToken(pt).transfer(msg.sender, MockToken(pt).balanceOf(address(this)));
-        MockToken(yt).transfer(msg.sender, MockToken(yt).balanceOf(address(this)));
-    }
-
-    function doRedeem(uint256 maturity, uint256 ptBal) external {
-        (address pt, , address yt, , , , , , ) = Divider(divider).series(address(this), maturity);
-        ERC20(pt).transferFrom(msg.sender, address(this), ptBal);
-        Divider(divider).redeem(address(this), maturity, ptBal);
-        MockTarget(target).transfer(msg.sender, MockTarget(target).balanceOf(address(this)));
-    }
-
-    function doCombine(uint256 maturity, uint256 uBal) external returns (uint256 tBal) {
-        tBal = Divider(divider).combine(address(this), maturity, uBal);
     }
 }
 


### PR DESCRIPTION
## Motivation

Fix bug on Divider about redeem restriction.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Implementer Checklist

<!--
Fill out the checklist below as applicable to your change. Bug fixes and new features must 
check off all of the required items.
-->


- [ ]  [FIRST TIME ONLY] Review the [Solcurity](https://github.com/Rari-Capital/solcurity) standard
- [ ]  [OPTIONAL] Create a reference implementation (in python or JS)
- [x]  Create a short "Motivation" section for the PR
- [ ]  Write a spec for the feature and put it in the PR description – basic function names and expected state transitions is OK
- [x]  Check all of the new revert paths with concrete tests
- [ ]  Check all of the new storage slot writes with concrete tests – do not make the passing test case the trivial case!
- [x]  Go line-by-line through the new code and ensure it has all been covered by concrete tests – since we don’t have a coverage engine for foundry yet, you can imagine how one might check that each different code path is covered
- [x]  Simplify the implementation and spend some time trying to minimize gas costs
- [ ]  Write fuzz tests for the feature – try everything to break the implementation (is this function monotonically in/decreasing, should it always be less than something else, etc)
- [x]  Capture bugs discovered during the above steps in concrete tests (regression tests)
- [ ]  Add integration tests – fuzz or concrete tests that test how the new code affects the entire system, either locally or with a mainnet fork
- [ ]  [OPTIONAL] Integrate the feature into the deployment scripts
- [ ]  [OPTIONAL] Add new sanity checks to the deployment scripts
- [ ]  Get the PR reviewed by at least two people