### PR TITLE
ref(crop): rename vars and colocate the Distributed event

### DIFF
--- a/pkg/core/src/adapters/abstract/extensions/Crop.sol
+++ b/pkg/core/src/adapters/abstract/extensions/Crop.sol
@@ -21,7 +21,7 @@ abstract contract Crop is Trust {
     /// @notice Program state
     address public claimer; // claimer address
     address public reward;
-    uint256 public share; // accumulated reward token per collected target
+    uint256 public shares; // accumulated reward token per collected target
     uint256 public rewardBal; // last recorded balance of reward token
     uint256 public totalTarget; // total target accumulated by all users
     mapping(address => uint256) public tBalance; // target balance per user
@@ -34,7 +34,7 @@ abstract contract Crop is Trust {
         reward = _reward;
     }
 
-    /// @notice Distribute the rewards tokens to the user according to their share
+    /// @notice Distribute the rewards tokens to the user according to their shares
     /// @dev The reconcile amount allows us to prevent diluting other users' rewards
     function notify(
         address _usr,
@@ -68,7 +68,7 @@ abstract contract Crop is Trust {
                 }
             }
         }
-        rewarded[_usr] = tBalance[_usr].fmulUp(share, FixedMath.RAY);
+        rewarded[_usr] = tBalance[_usr].fmulUp(shares, FixedMath.RAY);
     }
 
     /// @notice Reconciles users target balances to zero by distributing rewards on their holdings,
@@ -105,10 +105,10 @@ abstract contract Crop is Trust {
         _claimReward();
 
         uint256 crop = ERC20(reward).balanceOf(address(this)) - rewardBal;
-        if (totalTarget > 0) share += (crop.fdiv(totalTarget, FixedMath.RAY));
+        if (totalTarget > 0) shares += (crop.fdiv(totalTarget, FixedMath.RAY));
 
         uint256 last = rewarded[_usr];
-        uint256 curr = tBalance[_usr].fmul(share, FixedMath.RAY);
+        uint256 curr = tBalance[_usr].fmul(shares, FixedMath.RAY);
         if (curr > last) {
             unchecked {
                 ERC20(reward).safeTransfer(_usr, curr - last);

--- a/pkg/core/src/adapters/abstract/extensions/Crop.sol
+++ b/pkg/core/src/adapters/abstract/extensions/Crop.sol
@@ -29,8 +29,6 @@ abstract contract Crop is Trust {
     mapping(address => uint256) public reconciledAmt; // reconciled target amount per user
     mapping(address => mapping(uint256 => bool)) public reconciled; // whether a user has been reconciled for a given maturity
 
-    event Distributed(address indexed usr, address indexed token, uint256 amount);
-
     constructor(address _divider, address _reward) {
         setIsTrusted(_divider, true);
         reward = _reward;
@@ -157,6 +155,7 @@ abstract contract Crop is Trust {
 
     /* ========== LOGS ========== */
 
+    event Distributed(address indexed usr, address indexed token, uint256 amount);
     event Reconciled(address indexed usr, uint256 tBal, uint256 maturity);
     event RewardTokenChanged(address indexed reward);
     event ClaimerChanged(address indexed claimer);

--- a/pkg/core/src/adapters/abstract/extensions/Crops.sol
+++ b/pkg/core/src/adapters/abstract/extensions/Crops.sol
@@ -30,7 +30,7 @@ abstract contract Crops is Trust {
 
     struct Crop {
         // Accumulated reward token per collected target
-        uint256 share;
+        uint256 shares;
         // Last recorded balance of reward token
         uint256 rewardBal;
         // Rewarded token per user
@@ -75,7 +75,7 @@ abstract contract Crops is Trust {
             }
         }
         for (uint256 i = 0; i < rewardTokens.length; i++) {
-            data[rewardTokens[i]].rewarded[_usr] = tBalance[_usr].fmulUp(data[rewardTokens[i]].share, FixedMath.RAY);
+            data[rewardTokens[i]].rewarded[_usr] = tBalance[_usr].fmulUp(data[rewardTokens[i]].shares, FixedMath.RAY);
         }
     }
 
@@ -114,10 +114,10 @@ abstract contract Crops is Trust {
 
         for (uint256 i = 0; i < rewardTokens.length; i++) {
             uint256 crop = ERC20(rewardTokens[i]).balanceOf(address(this)) - data[rewardTokens[i]].rewardBal;
-            if (totalTarget > 0) data[rewardTokens[i]].share += (crop.fdiv(totalTarget, FixedMath.RAY));
+            if (totalTarget > 0) data[rewardTokens[i]].shares += (crop.fdiv(totalTarget, FixedMath.RAY));
 
             uint256 last = data[rewardTokens[i]].rewarded[_usr];
-            uint256 curr = tBalance[_usr].fmul(data[rewardTokens[i]].share, FixedMath.RAY);
+            uint256 curr = tBalance[_usr].fmul(data[rewardTokens[i]].shares, FixedMath.RAY);
             if (curr > last) {
                 unchecked {
                     ERC20(rewardTokens[i]).safeTransfer(_usr, curr - last);

--- a/pkg/core/src/adapters/abstract/extensions/Crops.sol
+++ b/pkg/core/src/adapters/abstract/extensions/Crops.sol
@@ -30,10 +30,10 @@ abstract contract Crops is Trust {
 
     struct Crop {
         // Accumulated reward token per collected target
-        uint256 shares;
-        // Last recorded balance of this contract per reward token
-        uint256 rewardedBalances;
-        // Rewarded token per token per user
+        uint256 share;
+        // Last recorded balance of reward token
+        uint256 rewardBal;
+        // Rewarded token per user
         mapping(address => uint256) rewarded;
     }
 
@@ -75,7 +75,7 @@ abstract contract Crops is Trust {
             }
         }
         for (uint256 i = 0; i < rewardTokens.length; i++) {
-            data[rewardTokens[i]].rewarded[_usr] = tBalance[_usr].fmulUp(data[rewardTokens[i]].shares, FixedMath.RAY);
+            data[rewardTokens[i]].rewarded[_usr] = tBalance[_usr].fmulUp(data[rewardTokens[i]].share, FixedMath.RAY);
         }
     }
 
@@ -113,17 +113,17 @@ abstract contract Crops is Trust {
         _claimRewards();
 
         for (uint256 i = 0; i < rewardTokens.length; i++) {
-            uint256 crop = ERC20(rewardTokens[i]).balanceOf(address(this)) - data[rewardTokens[i]].rewardedBalances;
-            if (totalTarget > 0) data[rewardTokens[i]].shares += (crop.fdiv(totalTarget, FixedMath.RAY));
+            uint256 crop = ERC20(rewardTokens[i]).balanceOf(address(this)) - data[rewardTokens[i]].rewardBal;
+            if (totalTarget > 0) data[rewardTokens[i]].share += (crop.fdiv(totalTarget, FixedMath.RAY));
 
             uint256 last = data[rewardTokens[i]].rewarded[_usr];
-            uint256 curr = tBalance[_usr].fmul(data[rewardTokens[i]].shares, FixedMath.RAY);
+            uint256 curr = tBalance[_usr].fmul(data[rewardTokens[i]].share, FixedMath.RAY);
             if (curr > last) {
                 unchecked {
                     ERC20(rewardTokens[i]).safeTransfer(_usr, curr - last);
                 }
             }
-            data[rewardTokens[i]].rewardedBalances = ERC20(rewardTokens[i]).balanceOf(address(this));
+            data[rewardTokens[i]].rewardBal = ERC20(rewardTokens[i]).balanceOf(address(this));
             emit Distributed(_usr, rewardTokens[i], curr > last ? curr - last : 0);
         }
     }


### PR DESCRIPTION
## Motivation

Some smol inconsistencies between `Crop.sol` and `Crops.sol`.

## Solution

Sync inconsistencies.