### PR TITLE
GEN-1733: combine to underlying

### DIFF
--- a/pkg/core/src/Periphery.sol
+++ b/pkg/core/src/Periphery.sol
@@ -486,7 +486,7 @@ contract Periphery is Trust, IERC3156FlashBorrower {
     /// @notice Reconstitute Target by burning PT and YT
     /// @param adapter Adapter address for the Series
     /// @param maturity Maturity date for the Series
-    /// @param amt Amount of PT and YT to burn
+    /// @param uBal Amount of PT and YT to burn
     /// @param receiver Address where the resulting Target will be transferred
     function combine(
         address adapter,
@@ -496,7 +496,7 @@ contract Periphery is Trust, IERC3156FlashBorrower {
     ) external returns (uint256 tBal) {
         ERC20(divider.pt(adapter, maturity)).safeTransferFrom(msg.sender, address(this), uBal); // Pull PTs
         ERC20(divider.yt(adapter, maturity)).safeTransferFrom(msg.sender, address(this), uBal); // Pull YTs
-        ERC20(Adapter(adapter).target()).safeTransfer(receiver, tBal = divider.combine(adapter, maturity, amt)); // Send Target to the receiver
+        ERC20(Adapter(adapter).target()).safeTransfer(receiver, tBal = divider.combine(adapter, maturity, uBal)); // Send Target to the receiver
     }
 
     /// @notice Reconstitute Target by burning PT and YT and unwrapping it


### PR DESCRIPTION
## Motivation

Add more flexibility to the Periphery by having the option both to combine PT and YTs to target (passthrough method to `divider.combine()` and to combine them to underlying (`divider.combine` + `adapter.unwrapTarget()`)

[Full spec here ](https://www.notion.so/sensefinance/22-12-19-Sense-Periphery-v2-0-Spec-da948b88bb45467aab543e9d177168b5)

## Solution



## Implementer Checklist

<!--
Fill out the checklist below as applicable to your change. Bug fixes and new features must 
check off all of the required items.
-->

- [ ]  [OPTIONAL] Create a reference implementation (in python or JS)
- [x]  Create a short "Motivation" section for the PR
- [x]  Write a spec for the feature and put it in the PR description – basic function names and expected state transitions is OK
- [ ]  Get the PR reviewed by at least two people

If this is your first time reviewing smart contract changes
- [ ]  Review the [Solcurity](https://github.com/Rari-Capital/solcurity) standard


If smart contract changes were made
- [x]  Check all of the new revert paths with concrete tests
- [ ]  Check all of the new storage slot writes with concrete tests – do not make the passing test case the trivial case!
- [x]  Go line-by-line through the new code and ensure it has all been covered by concrete tests – since we don’t have a coverage engine for foundry yet, you can imagine how one might check that each different code path is covered
- [x]  Simplify the implementation and spend some time trying to minimize gas costs
- [ ]  Write fuzz tests for the feature – try everything to break the implementation (is this function monotonically in/decreasing, should it always be less than something else, etc)
- [ ]  Capture bugs discovered during the above steps in concrete tests (regression tests)
- [x]  Add integration tests – fuzz or concrete tests that test how the new code affects the entire system, either locally or with a mainnet fork
- [ ]  [OPTIONAL] Integrate the feature into the deployment scripts
- [ ]  [OPTIONAL] Add new sanity checks to the deployment scripts

If your PR uses or interacts with prices of any kind
- [ ] Make sure forge is running the test on the latest block
- [ ] Compare the value returned with some other source (like Curve)
- [ ] Check the `updatedAt` (if available) value of the contract and confirm that the price we are sourcing is in fact not older than X
- [ ] Ensure oracle liveness from the oracle maintainer, either through a public status interface or through written confirmation from a developer.