### PR TITLE
GEN-1732: auto redeem

### DIFF
--- a/pkg/core/src/tests/Periphery.t.sol
+++ b/pkg/core/src/tests/Periphery.t.sol
@@ -693,8 +693,10 @@ contract PeripheryTest is TestHelper {
         vm.prank(from);
         ERC20(pt).approve(address(periphery), ptBalBefore);
 
-        vm.expectEmit(true, false, false, false);
-        emit PTRedeemed(address(adapter), maturity, 0);
+        (, , , , , , , uint256 mscale, ) = divider.series(address(adapter), maturity);
+        uint256 tBalRedeemed = ptBalBefore.fdiv(mscale);
+        vm.expectEmit(true, true, true, false);
+        emit PTRedeemed(address(adapter), maturity, tBalRedeemed);
 
         vm.prank(from);
         uint256 redeemed = periphery.swapPTsForTarget(address(adapter), maturity, ptBalBefore, 0, receiver);

--- a/pkg/core/src/tests/Periphery.t.sol
+++ b/pkg/core/src/tests/Periphery.t.sol
@@ -670,6 +670,39 @@ contract PeripheryTest is TestHelper {
         assertEq(tBalBefore + swapped, target.balanceOf(receiver));
     }
 
+    function testSwapFuzzPTsForTargetAutoRedeem(address from, address receiver) public {
+        uint256 tBal = 100 * 10**tDecimals;
+        uint256 maturity = getValidMaturity(2021, 10);
+
+        (address pt, ) = periphery.sponsorSeries(address(adapter), maturity, true);
+
+        // add liquidity to mockBalancerVault
+        addLiquidityToBalancerVault(maturity, 1000e18);
+
+        initUser(from, target, tBal);
+        vm.prank(from);
+        divider.issue(address(adapter), maturity, tBal);
+
+        // settle series
+        vm.warp(maturity);
+        divider.settleSeries(address(adapter), maturity);
+
+        uint256 tBalBefore = ERC20(adapter.target()).balanceOf(receiver);
+        uint256 ptBalBefore = ERC20(pt).balanceOf(receiver);
+
+        vm.prank(from);
+        ERC20(pt).approve(address(periphery), ptBalBefore);
+
+        vm.expectEmit(true, false, false, false);
+        emit PTRedeemed(address(adapter), maturity, 0);
+
+        vm.prank(from);
+        uint256 redeemed = periphery.swapPTsForTarget(address(adapter), maturity, ptBalBefore, 0, receiver);
+        uint256 ptBalAfter = ERC20(pt).balanceOf(receiver);
+        assertEq(ptBalAfter, 0);
+        assertEq(tBalBefore + redeemed, target.balanceOf(receiver));
+    }
+
     function testFuzzSwapPTsForUnderlying(address from, address receiver) public {
         uint256 tBal = 100 * 10**tDecimals;
         uint256 maturity = getValidMaturity(2021, 10);
@@ -1585,6 +1618,7 @@ contract PeripheryTest is TestHelper {
         uint256 amountOut,
         bytes4 indexed sig
     );
+    event PTRedeemed(address indexed adapter, uint256 indexed maturity, uint256 redeemed);
 
     // Pool Manager
     event TargetAdded(address indexed target, address indexed cTarget);


### PR DESCRIPTION
## Motivation

Using `swapPTsForTarget` or `swapPTsForUnderlying` should automatically try redeeming PTs on the Divider instead of executing the `_swap` method when a Series has already been settled (since PTs would be 1:1 with the underlying). 

[Full spec here](https://www.notion.so/sensefinance/22-12-19-Sense-Periphery-v2-0-Spec-da948b88bb45467aab543e9d177168b5#8281f494e53a490da7e8cd85beb06bdb)

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Implementer Checklist

<!--
Fill out the checklist below as applicable to your change. Bug fixes and new features must 
check off all of the required items.
-->

- [ ]  [OPTIONAL] Create a reference implementation (in python or JS)
- [x]  Create a short "Motivation" section for the PR
- [x]  Write a spec for the feature and put it in the PR description – basic function names and expected state transitions is OK
- [ ]  Get the PR reviewed by at least two people

If this is your first time reviewing smart contract changes
- [ ]  Review the [Solcurity](https://github.com/Rari-Capital/solcurity) standard


If smart contract changes were made
- [x]  Check all of the new revert paths with concrete tests
- [ ]  Check all of the new storage slot writes with concrete tests – do not make the passing test case the trivial case!
- [x]  Go line-by-line through the new code and ensure it has all been covered by concrete tests – since we don’t have a coverage engine for foundry yet, you can imagine how one might check that each different code path is covered
- [x]  Simplify the implementation and spend some time trying to minimize gas costs
- [ ]  Write fuzz tests for the feature – try everything to break the implementation (is this function monotonically in/decreasing, should it always be less than something else, etc)
- [ ]  Capture bugs discovered during the above steps in concrete tests (regression tests)
- [x]  Add integration tests – fuzz or concrete tests that test how the new code affects the entire system, either locally or with a mainnet fork
- [ ]  [OPTIONAL] Integrate the feature into the deployment scripts
- [ ]  [OPTIONAL] Add new sanity checks to the deployment scripts

If your PR uses or interacts with prices of any kind
- [ ] Make sure forge is running the test on the latest block
- [ ] Compare the value returned with some other source (like Curve)
- [ ] Check the `updatedAt` (if available) value of the contract and confirm that the price we are sourcing is in fact not older than X
- [ ] Ensure oracle liveness from the oracle maintainer, either through a public status interface or through written confirmation from a developer.