### PR TITLE
GEN-2022: add function to set factory params

### DIFF
--- a/pkg/core/src/adapters/abstract/factories/BaseFactory.sol
+++ b/pkg/core/src/adapters/abstract/factories/BaseFactory.sol
@@ -140,8 +140,16 @@ abstract contract BaseFactory is Trust {
         Trust(_adapter).setIsTrusted(_user, _trusted);
     }
 
+    /// Set factory params
+    /// @dev existing adapters will not be affected
+    function setFactoryParams(FactoryParams calldata _factoryParams) external requiresTrust {
+        emit FactoryParamsChanged(_factoryParams);
+        factoryParams = _factoryParams;
+    }
+
     /* ========== LOGS ========== */
 
     event RewardsRecipientChanged(address indexed oldRecipient, address indexed newRecipient);
     event RestrictedAdminChanged(address indexed oldAdmin, address indexed newAdmin);
+    event FactoryParamsChanged(FactoryParams factoryParams);
 }

--- a/pkg/core/src/tests/factories/BaseFactory.t.sol
+++ b/pkg/core/src/tests/factories/BaseFactory.t.sol
@@ -352,8 +352,55 @@ contract Factories is TestHelper {
         assertEq(factory.rewardsRecipient(), address(0x111));
     }
 
+    function testSetFactoryParams() public {
+        BaseFactory.FactoryParams memory factoryParams;
+        
+        // Can not set factory params if not trusted
+        vm.expectRevert("UNTRUSTED");
+        vm.prank(address(0x123));
+        factory.setFactoryParams(factoryParams);
+
+        // Can set rewards recipient
+        factoryParams.stake = address(0xFED);
+        factoryParams.oracle = address(0xFED);
+        factoryParams.ifee = 111e18;
+        factoryParams.stakeSize = 111e18;
+        factoryParams.minm = 111e18;
+        factoryParams.maxm = 111e18;
+        factoryParams.mode = 1;
+        factoryParams.tilt = 1;
+        factoryParams.guard = 111e1;
+
+        vm.expectEmit(true, true, true, true);
+        emit FactoryParamsChanged(factoryParams);
+        factory.setFactoryParams(factoryParams);
+
+        (
+            address oracle,
+            address stake,
+            uint256 stakeSize,
+            uint256 minm,
+            uint256 maxm,
+            uint256 ifee,
+            uint16 mode,
+            uint64 tilt,
+            uint256 guard
+        ) = factory.factoryParams();
+
+        assertEq(stake, factoryParams.stake);
+        assertEq(oracle, factoryParams.oracle);
+        assertEq(stakeSize, factoryParams.stakeSize);
+        assertEq(minm, factoryParams.minm);
+        assertEq(maxm, factoryParams.maxm);
+        assertEq(ifee, factoryParams.ifee);
+        assertEq(mode, factoryParams.mode);
+        assertEq(tilt, factoryParams.tilt);
+        assertEq(guard, factoryParams.guard);
+    }
+
     /* ========== LOGS ========== */
 
     event RewardsRecipientChanged(address indexed recipient, address indexed newRecipient);
     event RestrictedAdminChanged(address indexed admin, address indexed newAdmin);
+    event FactoryParamsChanged(BaseFactory.FactoryParams factoryParams);
 }

--- a/pkg/core/src/tests/factories/BaseFactory.t.sol
+++ b/pkg/core/src/tests/factories/BaseFactory.t.sol
@@ -354,7 +354,7 @@ contract Factories is TestHelper {
 
     function testSetFactoryParams() public {
         BaseFactory.FactoryParams memory factoryParams;
-        
+
         // Can not set factory params if not trusted
         vm.expectRevert("UNTRUSTED");
         vm.prank(address(0x123));


### PR DESCRIPTION
## Motivation

Make our factories more flexible.

## Solution

Add `setFactoryParams` to BaseFactory.sol

## Implementer Checklist

<!--
Fill out the checklist below as applicable to your change. Bug fixes and new features must 
check off all of the required items.
-->

- [ ]  [OPTIONAL] Create a reference implementation (in python or JS)
- [x]  Create a short "Motivation" section for the PR
- [x]  Write a spec for the feature and put it in the PR description – basic function names and expected state transitions is OK
- [ ]  Get the PR reviewed by at least two people

If this is your first time reviewing smart contract changes
- [ ]  Review the [Solcurity](https://github.com/Rari-Capital/solcurity) standard


If smart contract changes were made
- [x]  Check all of the new revert paths with concrete tests
- [ ]  Check all of the new storage slot writes with concrete tests – do not make the passing test case the trivial case!
- [x]  Go line-by-line through the new code and ensure it has all been covered by concrete tests – since we don’t have a coverage engine for foundry yet, you can imagine how one might check that each different code path is covered
- [ ]  Simplify the implementation and spend some time trying to minimize gas costs
- [ ]  Write fuzz tests for the feature – try everything to break the implementation (is this function monotonically in/decreasing, should it always be less than something else, etc)
- [ ]  Capture bugs discovered during the above steps in concrete tests (regression tests)
- [ ]  Add integration tests – fuzz or concrete tests that test how the new code affects the entire system, either locally or with a mainnet fork
- [ ]  [OPTIONAL] Integrate the feature into the deployment scripts
- [ ]  [OPTIONAL] Add new sanity checks to the deployment scripts

If your PR uses or interacts with prices of any kind
- [ ] Make sure forge is running the test on the latest block
- [ ] Compare the value returned with some other source (like Curve)
- [ ] Check the `updatedAt` (if available) value of the contract and confirm that the price we are sourcing is in fact not older than X
- [ ] Ensure oracle liveness from the oracle maintainer, either through a public status interface or through written confirmation from a developer.