### PR TITLE
feat: make swapYTsForTarget helpers not succeed from external calls

### DIFF
--- a/pkg/core/src/Periphery.sol
+++ b/pkg/core/src/Periphery.sol
@@ -338,7 +338,7 @@ contract Periphery is Trust, IERC3156FlashBorrower {
         uint256 maturity,
         uint256 ytBal,
         PermitData calldata permit
-    ) external returns (uint256 amt){
+    ) external returns (uint256 amt) {
         if (msg.sender != address(this)) revert Errors.OnlyPeriphery();
         amt = _swapYTsForTarget(sender, adapter, maturity, ytBal, block.timestamp, permit);
     }

--- a/pkg/core/src/Periphery.sol
+++ b/pkg/core/src/Periphery.sol
@@ -338,7 +338,8 @@ contract Periphery is Trust, IERC3156FlashBorrower {
         uint256 maturity,
         uint256 ytBal,
         PermitData calldata permit
-    ) external onlyThis returns (uint256 amt){
+    ) external returns (uint256 amt){
+        if (msg.sender != address(this)) revert Errors.OnlyPeriphery();
         amt = _swapYTsForTarget(sender, adapter, maturity, ytBal, block.timestamp, permit);
     }
 
@@ -1103,13 +1104,6 @@ contract Periphery is Trust, IERC3156FlashBorrower {
 
     // required for refunds
     receive() external payable {}
-
-    /* ========== MODIFIERS ========== */
-
-    modifier onlyThis() {
-        if (msg.sender != address(this)) revert Errors.OnlyPeriphery();
-        _;
-    }
 
     /* ========== LOGS ========== */
 

--- a/pkg/core/src/Periphery.sol
+++ b/pkg/core/src/Periphery.sol
@@ -322,15 +322,24 @@ contract Periphery is Trust, IERC3156FlashBorrower {
         uint256 ytBal
     ) external returns (uint256 amt) {
         ERC20(divider.yt(adapter, maturity)).transferFrom(msg.sender, address(this), ytBal);
-        amt = this._swapYTsForTarget(
+        amt = this.swapYTsForTargetHelper(
             msg.sender,
             adapter,
             maturity,
             ytBal,
-            block.timestamp,
             PermitData(IPermit2.PermitTransferFrom(IPermit2.TokenPermissions(ERC20(address(0)), 0), 0, 0), "0x")
         );
         _transfer(ERC20(Adapter(adapter).target()), msg.sender, amt);
+    }
+
+    function swapYTsForTargetHelper(
+        address sender,
+        address adapter,
+        uint256 maturity,
+        uint256 ytBal,
+        PermitData calldata permit
+    ) external onlyThis returns (uint256 amt){
+        amt = _swapYTsForTarget(sender, adapter, maturity, ytBal, block.timestamp, permit);
     }
 
     function _swapSenseToken(
@@ -612,7 +621,7 @@ contract Periphery is Trust, IERC3156FlashBorrower {
         uint256 ytBal,
         uint256 deadline,
         PermitData calldata permit
-    ) public returns (uint256 tBal) {
+    ) internal returns (uint256 tBal) {
         // Because there's some margin of error in the pricing functions here, smaller
         // swaps will be unreliable. Tokens with more than 18 decimals are not supported.
         if (ytBal * 10**(18 - ERC20(divider.yt(adapter, maturity)).decimals()) <= MIN_YT_SWAP_IN)
@@ -1094,6 +1103,13 @@ contract Periphery is Trust, IERC3156FlashBorrower {
 
     // required for refunds
     receive() external payable {}
+
+    /* ========== MODIFIERS ========== */
+
+    modifier onlyThis() {
+        if (msg.sender != address(this)) revert Errors.OnlyPeriphery();
+        _;
+    }
 
     /* ========== LOGS ========== */
 

--- a/pkg/core/src/tests/Periphery.tm.sol
+++ b/pkg/core/src/tests/Periphery.tm.sol
@@ -945,7 +945,7 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
     }
 
 
-    function testMainnetCannotCallSwapYTsForTargetHelper() public {
+    function testMainnetFuzzCannotCallSwapYTsForTargetHelper(address from) public {
         // 1. Sponsor a Series
         (uint256 maturity, address pt, address yt) = _sponsorSeries();
 
@@ -953,7 +953,7 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         _initializePool(maturity, ERC20(pt), 1e18, 0.5e18);
 
         // 3. Swap 10% of bob's YTs for Target
-        vm.startPrank(bob);
+        vm.startPrank(from);
         uint256 ytBalPre = ERC20(yt).balanceOf(bob);
         uint256 targetBalPre = mockTarget.balanceOf(bob);
 

--- a/pkg/core/src/tests/Periphery.tm.sol
+++ b/pkg/core/src/tests/Periphery.tm.sol
@@ -944,7 +944,6 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         assertGt(targetBalPost, targetBalPre);
     }
 
-
     function testMainnetFuzzCannotCallSwapYTsForTargetHelper(address from) public {
         // 1. Sponsor a Series
         (uint256 maturity, address pt, address yt) = _sponsorSeries();

--- a/pkg/core/src/tests/Periphery.tm.sol
+++ b/pkg/core/src/tests/Periphery.tm.sol
@@ -944,6 +944,25 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         assertGt(targetBalPost, targetBalPre);
     }
 
+
+    function testMainnetCannotCallSwapYTsForTargetHelper() public {
+        // 1. Sponsor a Series
+        (uint256 maturity, address pt, address yt) = _sponsorSeries();
+
+        // 2. Initialize the pool by joining 0.5 Target in, then swapping 0.5 PTs in for Target
+        _initializePool(maturity, ERC20(pt), 1e18, 0.5e18);
+
+        // 3. Swap 10% of bob's YTs for Target
+        vm.startPrank(bob);
+        uint256 ytBalPre = ERC20(yt).balanceOf(bob);
+        uint256 targetBalPre = mockTarget.balanceOf(bob);
+
+        Periphery.PermitData memory data = generatePermit(bobPrivKey, address(periphery), address(yt));
+
+        vm.expectRevert(Errors.OnlyPeriphery.selector);
+        periphery.swapYTsForTargetHelper(bob, address(mockAdapter), maturity, ytBalPre / 10, data);
+    }
+
     function testMainnetSwapTargetForYTsReturnValues() public {
         // 1. Sponsor a Series
         (uint256 maturity, address pt, address yt) = _sponsorSeries();


### PR DESCRIPTION
## Motivation

Make code internal intended to be supporting logic to remove unnecessary external access. Previously `_swapYTsForTarget` was an external function as a work around to reduce contract size and maintain gas efficiency of having PermitData as a `calldata` param instead of a `memory` param.

## Solution

Make _swapYTsForTarget() an internal function.

Add an additional helper function for the external `swapYTsForTarget` with an onlyThis modifier. This allows the `swapYTsForTarget` to use the external helper function to then make use of the internal `_swapYTsForTarget` function via the helper, without making PermitData a memory param in `_swapYTsForTarget`.

Since the PermitData value in swapYTsForTarget is in memory, the internal function _swapYTsForTarget cannot be called directly without updating the _swapYTsForTarget to have PermitData as a memory param.

## Implementer Checklist

Added additional test to confirm access validation via the `onlyThis` modifier.