### PR TITLE
Test should support ERC20 tokens that do not return bool

### DIFF
--- a/pkg/core/src/tests/erc4626/ERC4626.tm.sol
+++ b/pkg/core/src/tests/erc4626/ERC4626.tm.sol
@@ -5,6 +5,7 @@ import "./ERC4626.test.sol";
 
 import { ERC20 } from "solmate/tokens/ERC20.sol";
 import { ERC4626 } from "solmate/mixins/ERC4626.sol";
+import {SafeTransferLib} from "solmate/utils/SafeTransferLib.sol";
 import { AddressBook } from "@sense-finance/v1-utils/addresses/AddressBook.sol";
 import { ForkTest } from "@sense-finance/v1-core/tests/test-helpers/ForkTest.sol";
 
@@ -41,7 +42,7 @@ contract ERC4626StdTest is ERC4626Test, ForkTest {
         if (userWithAssets != address(0)) {
             // init vault
             vm.startPrank(userWithAssets);
-            ERC20(_underlying_).approve(_vault_, type(uint256).max);
+            _safeApprove(_underlying_, _vault_,type(uint256).max);
             IERC4626(_vault_).deposit(1 * 10**ERC20(_underlying_).decimals(), userWithAssets);
             vm.stopPrank();
 
@@ -79,7 +80,7 @@ contract ERC4626StdTest is ERC4626Test, ForkTest {
                 init.asset[i] = bound(init.asset[i], 0, maxAssetPerUser);
                 uint256 assets = init.asset[i];
                 vm.prank(userWithAssets);
-                ERC20(_underlying_).transfer(user, assets);
+                SafeTransferLib.safeTransfer(ERC20(_underlying_), user, assets);
             }
 
             if (_needsRolling) vm.roll(block.number + 1);


### PR DESCRIPTION
## Motivation


I tried running the ERC4626 property test against a vault with USDT as underlying token, I found that when the test is executed with a userWithAsset for this token, the test would fail as USDT token doesn't return boolean when approve and transfer is called


## Solution
I have replaced ERC20.approve and ERC20.transfer with  _safeApprove and _safeTransfer to solve this issue 

cc : @fedealconada 