### PR TITLE
fix: add sponsorSeries backwards-compatible with RLV function

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
         FORK_TOP_UP: ${{ secrets.FORK_TOP_UP }}
         MAINNET_RPC_URL: "test"
         GOERLI_RPC_URL: "test"
+        ZEROEX_API_KEY: ${{ secrets.ZEROEX_API_KEY }}
 
     - name: Check code coverage
       run: yarn coverage

--- a/pkg/core/src/Periphery.sol
+++ b/pkg/core/src/Periphery.sol
@@ -18,7 +18,6 @@ import { BaseAdapter as Adapter } from "./adapters/abstract/BaseAdapter.sol";
 import { BaseFactory as AdapterFactory } from "./adapters/abstract/factories/BaseFactory.sol";
 import { Divider } from "./Divider.sol";
 
-
 interface SpaceFactoryLike {
     function create(address, uint256) external returns (address);
 
@@ -323,10 +322,14 @@ contract Periphery is Trust, IERC3156FlashBorrower {
         uint256 ytBal
     ) external returns (uint256 amt) {
         ERC20(divider.yt(adapter, maturity)).transferFrom(msg.sender, address(this), ytBal);
-        amt = this._swapYTsForTarget(msg.sender, adapter, maturity, ytBal, block.timestamp, PermitData(
-            IPermit2.PermitTransferFrom(IPermit2.TokenPermissions(ERC20(address(0)), 0), 0, 0),
-            "0x"
-        ));
+        amt = this._swapYTsForTarget(
+            msg.sender,
+            adapter,
+            maturity,
+            ytBal,
+            block.timestamp,
+            PermitData(IPermit2.PermitTransferFrom(IPermit2.TokenPermissions(ERC20(address(0)), 0), 0, 0), "0x")
+        );
         _transfer(ERC20(Adapter(adapter).target()), msg.sender, amt);
     }
 
@@ -616,7 +619,8 @@ contract Periphery is Trust, IERC3156FlashBorrower {
             revert Errors.SwapTooSmall();
 
         // Transfer YTs into this contract if needed
-        if (sender != address(this) && msg.sender != address(this)) _transferFrom(permit, divider.yt(adapter, maturity), ytBal);
+        if (sender != address(this) && msg.sender != address(this))
+            _transferFrom(permit, divider.yt(adapter, maturity), ytBal);
 
         // Calculate target to borrow by calling AMM
         uint256 targetToBorrow;

--- a/pkg/core/src/Periphery.sol
+++ b/pkg/core/src/Periphery.sol
@@ -322,15 +322,24 @@ contract Periphery is Trust, IERC3156FlashBorrower {
         uint256 ytBal
     ) external returns (uint256 amt) {
         ERC20(divider.yt(adapter, maturity)).transferFrom(msg.sender, address(this), ytBal);
-        amt = this._swapYTsForTarget(
+        amt = this.swapYTsForTargetHelper(
             msg.sender,
             adapter,
             maturity,
             ytBal,
-            block.timestamp,
             PermitData(IPermit2.PermitTransferFrom(IPermit2.TokenPermissions(ERC20(address(0)), 0), 0, 0), "0x")
         );
         _transfer(ERC20(Adapter(adapter).target()), msg.sender, amt);
+    }
+
+    function swapYTsForTargetHelper(
+        address sender,
+        address adapter,
+        uint256 maturity,
+        uint256 ytBal,
+        PermitData calldata permit
+    ) external onlyThis returns (uint256 amt){
+        amt = _swapYTsForTarget(sender, adapter, maturity, ytBal, block.timestamp, permit);
     }
 
     function _swapSenseToken(
@@ -612,7 +621,7 @@ contract Periphery is Trust, IERC3156FlashBorrower {
         uint256 ytBal,
         uint256 deadline,
         PermitData calldata permit
-    ) public returns (uint256 tBal) {
+    ) internal returns (uint256 tBal) {
         // Because there's some margin of error in the pricing functions here, smaller
         // swaps will be unreliable. Tokens with more than 18 decimals are not supported.
         if (ytBal * 10**(18 - ERC20(divider.yt(adapter, maturity)).decimals()) <= MIN_YT_SWAP_IN)
@@ -1094,6 +1103,13 @@ contract Periphery is Trust, IERC3156FlashBorrower {
 
     // required for refunds
     receive() external payable {}
+
+    /* ========== MODIFIERS ========== */
+
+    modifier onlyThis() {
+        if (msg.sender != address(this)) revert Errors.OnlyPeriphery();
+        _;
+    }
 
     /* ========== LOGS ========== */
 

--- a/pkg/core/src/Periphery.sol
+++ b/pkg/core/src/Periphery.sol
@@ -172,7 +172,7 @@ contract Periphery is Trust, IERC3156FlashBorrower {
         address adapter,
         uint256 maturity,
         bool withPool,
-        address stake, 
+        address stake,
         uint256 stakeSize
     ) internal returns (address pt, address yt) {
         ERC20(stake).transferFrom(msg.sender, address(this), stakeSize);
@@ -1132,13 +1132,6 @@ contract Periphery is Trust, IERC3156FlashBorrower {
 
     // required for refunds
     receive() external payable {}
-
-    /* ========== MODIFIERS ========== */
-
-    modifier onlyThis() {
-        if (msg.sender != address(this)) revert Errors.OnlyPeriphery();
-        _;
-    }
 
     /* ========== LOGS ========== */
 

--- a/pkg/core/src/Periphery.sol
+++ b/pkg/core/src/Periphery.sol
@@ -129,6 +129,22 @@ contract Periphery is Trust, IERC3156FlashBorrower {
     function sponsorSeries(
         address adapter,
         uint256 maturity,
+        bool withPool
+    ) external returns (address pt, address yt) {
+        (, address stake, uint256 stakeSize) = Adapter(adapter).getStakeAndTarget();
+        return _sponsorSeries(adapter, maturity, withPool, stake, stakeSize);
+    }
+
+    /// @notice Sponsor a new Series in any adapter previously onboarded onto the Divider
+    /// @dev Called by an external address, initializes a new series in the Divider
+    /// @param adapter Adapter to associate with the Series
+    /// @param maturity Maturity date for the Series, in units of unix time
+    /// @param withPool Whether to deploy a Space pool or not (only works for unverified adapters)
+    /// @param permit Permit to pull the tokens to swap from
+    /// @param quote Quote with swap details
+    function sponsorSeries(
+        address adapter,
+        uint256 maturity,
         bool withPool,
         PermitData calldata permit,
         SwapQuote calldata quote
@@ -136,6 +152,30 @@ contract Periphery is Trust, IERC3156FlashBorrower {
         (, address stake, uint256 stakeSize) = Adapter(adapter).getStakeAndTarget();
         if (address(quote.sellToken) != ETH) _transferFrom(permit, address(quote.sellToken), quote.amount);
         if (address(quote.sellToken) != stake) _fillQuote(quote);
+
+        (pt, yt) = _sponsorSeries(adapter, maturity, withPool, stake, stakeSize);
+
+        // refund any excess stake assets
+        ERC20(stake).safeTransfer(msg.sender, _balanceOf(stake, address(this)));
+
+        // refund any remaining quote.sellToken to receiver
+        _transfer(
+            quote.sellToken,
+            msg.sender,
+            address(quote.sellToken) == ETH
+                ? address(this).balance
+                : _balanceOf(address(quote.sellToken), address(this))
+        );
+    }
+
+    function _sponsorSeries(
+        address adapter,
+        uint256 maturity,
+        bool withPool,
+        address stake, 
+        uint256 stakeSize
+    ) internal returns (address pt, address yt) {
+        ERC20(stake).transferFrom(msg.sender, address(this), stakeSize);
 
         // Approve divider to withdraw stake assets
         ERC20(stake).safeApprove(address(divider), stakeSize);
@@ -151,18 +191,6 @@ contract Periphery is Trust, IERC3156FlashBorrower {
                 spaceFactory.create(adapter, maturity);
             }
         }
-
-        // refund any excess stake assets
-        ERC20(stake).safeTransfer(msg.sender, _balanceOf(stake, address(this)));
-
-        // refund any remaining quote.sellToken to receiver
-        _transfer(
-            quote.sellToken,
-            msg.sender,
-            address(quote.sellToken) == ETH
-                ? address(this).balance
-                : _balanceOf(address(quote.sellToken), address(this))
-        );
 
         emit SeriesSponsored(adapter, maturity, msg.sender);
     }

--- a/pkg/core/src/Periphery.sol
+++ b/pkg/core/src/Periphery.sol
@@ -132,6 +132,7 @@ contract Periphery is Trust, IERC3156FlashBorrower {
         bool withPool
     ) external returns (address pt, address yt) {
         (, address stake, uint256 stakeSize) = Adapter(adapter).getStakeAndTarget();
+        ERC20(stake).transferFrom(msg.sender, address(this), stakeSize);
         return _sponsorSeries(adapter, maturity, withPool, stake, stakeSize);
     }
 
@@ -175,8 +176,6 @@ contract Periphery is Trust, IERC3156FlashBorrower {
         address stake,
         uint256 stakeSize
     ) internal returns (address pt, address yt) {
-        ERC20(stake).transferFrom(msg.sender, address(this), stakeSize);
-
         // Approve divider to withdraw stake assets
         ERC20(stake).safeApprove(address(divider), stakeSize);
 

--- a/pkg/core/src/Periphery.sol
+++ b/pkg/core/src/Periphery.sol
@@ -18,6 +18,7 @@ import { BaseAdapter as Adapter } from "./adapters/abstract/BaseAdapter.sol";
 import { BaseFactory as AdapterFactory } from "./adapters/abstract/factories/BaseFactory.sol";
 import { Divider } from "./Divider.sol";
 
+
 interface SpaceFactoryLike {
     function create(address, uint256) external returns (address);
 
@@ -321,12 +322,12 @@ contract Periphery is Trust, IERC3156FlashBorrower {
         uint256 maturity,
         uint256 ytBal
     ) external returns (uint256 amt) {
-        if (msg.sender != adapter) revert Errors.OnlyAdapter();
-        PermitData memory permit = PermitData(
+        ERC20(divider.yt(adapter, maturity)).transferFrom(msg.sender, address(this), ytBal);
+        amt = this._swapYTsForTarget(msg.sender, adapter, maturity, ytBal, block.timestamp, PermitData(
             IPermit2.PermitTransferFrom(IPermit2.TokenPermissions(ERC20(address(0)), 0), 0, 0),
             "0x"
-        );
-        amt = this._swapYTsForTarget(msg.sender, adapter, maturity, ytBal, block.timestamp, permit);
+        ));
+        _transfer(ERC20(Adapter(adapter).target()), msg.sender, amt);
     }
 
     function _swapSenseToken(
@@ -615,7 +616,7 @@ contract Periphery is Trust, IERC3156FlashBorrower {
             revert Errors.SwapTooSmall();
 
         // Transfer YTs into this contract if needed
-        if (sender != address(this)) _transferFrom(permit, divider.yt(adapter, maturity), ytBal);
+        if (sender != address(this) && msg.sender != address(this)) _transferFrom(permit, divider.yt(adapter, maturity), ytBal);
 
         // Calculate target to borrow by calling AMM
         uint256 targetToBorrow;

--- a/pkg/core/src/tests/Periphery.t.sol
+++ b/pkg/core/src/tests/Periphery.t.sol
@@ -67,6 +67,30 @@ contract PeripheryTest is TestHelper {
         // assertTrue(status == PoolManager.SeriesStatus.QUEUED);
     }
 
+    function testNonPermitSponsorSeries() public {
+        uint256 maturity = getValidMaturity(2021, 10);
+
+        vm.expectEmit(true, true, true, true);
+        emit SeriesSponsored(address(adapter), maturity, bob);
+
+        // load bob's wallet with 1 stake
+        deal(address(stake), bob, 1e18);
+
+        // approve Periphery to pull Bob's stake
+        vm.prank(bob);
+        stake.approve(address(periphery), 1e18);
+
+        vm.prank(bob);
+        (address pt, address yt) = periphery.sponsorSeries(address(adapter), maturity, true);
+
+        // check pt and yt deployed
+        assertTrue(pt != address(0));
+        assertTrue(yt != address(0));
+
+        // check Space pool is deployed
+        assertTrue(address(spaceFactory.pool()) != address(0));
+    }
+
     function testSponsorSeriesWhenUnverifiedAdapter() public {
         divider.setPermissionless(true);
         MockCropAdapter adapter = new MockCropAdapter(

--- a/pkg/core/src/tests/Periphery.t.sol
+++ b/pkg/core/src/tests/Periphery.t.sol
@@ -70,15 +70,15 @@ contract PeripheryTest is TestHelper {
     function testNonPermitSponsorSeries() public {
         uint256 maturity = getValidMaturity(2021, 10);
 
-        vm.expectEmit(true, true, true, true);
-        emit SeriesSponsored(address(adapter), maturity, bob);
-
         // load bob's wallet with 1 stake
         deal(address(stake), bob, 1e18);
 
         // approve Periphery to pull Bob's stake
         vm.prank(bob);
         stake.approve(address(periphery), 1e18);
+
+        vm.expectEmit(true, true, true, true);
+        emit SeriesSponsored(address(adapter), maturity, bob);
 
         vm.prank(bob);
         (address pt, address yt) = periphery.sponsorSeries(address(adapter), maturity, true);
@@ -751,11 +751,12 @@ contract PeripheryTest is TestHelper {
         // calculate underlying swapped to pt
         uint256 ptBal = tBal.fdiv(balancerVault.EXCHANGE_RATE());
 
+        initUser(bob, target, uBal);
+        Periphery.PermitData memory data = generatePermit(bobPrivKey, address(periphery), address(underlying));
+
         vm.expectEmit(true, false, false, false);
         emit Swapped(bob, "0", adapter.target(), address(0), 0, 0, msg.sig);
 
-        initUser(bob, target, uBal);
-        Periphery.PermitData memory data = generatePermit(bobPrivKey, address(periphery), address(underlying));
         vm.prank(bob);
         periphery.swapForPTs(
             address(adapter),

--- a/pkg/core/src/tests/Periphery.tm.sol
+++ b/pkg/core/src/tests/Periphery.tm.sol
@@ -614,18 +614,14 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         uint256 amt = 10**token.decimals(); // 1 DAI
         // Create quote from 0x API to do a 1 DAI to underlying (stETH) swap
         Periphery.SwapQuote memory quote = _getBuyUnderlyingQuote(adapter, AddressBook.DAI);
-        vm.expectEmit(true, true, false, false);
-        emit BoughtTokens(AddressBook.DAI, MockAdapter(adapter).underlying(), 0, 0);
-        _addLiquidityFromToken(adapter, maturity, quote, amt);
+        _addLiquidityFromToken(adapter, maturity, quote, amt, true);
         deal(AddressBook.WSTETH, address(periphery), 0); // reset Periphery's target balance
 
         // 2. Add liquidity from ETH
         amt = 1e18; // 1 ETH
         // Create quote from 0x API to do a 1 ETH to underlying (stETH) swap
         quote = _getBuyUnderlyingQuote(adapter, periphery.ETH());
-        vm.expectEmit(true, true, false, false);
-        emit BoughtTokens(periphery.ETH(), MockAdapter(adapter).underlying(), 0, 0);
-        _addLiquidityFromETH(adapter, maturity, quote, amt);
+        _addLiquidityFromETH(adapter, maturity, quote, amt, true);
         deal(AddressBook.WSTETH, address(periphery), 0); // reset Periphery's target balance
 
         // 3.1 Add liquidity from Target
@@ -634,7 +630,7 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         // Create quote only with sellToken as target. We don't care about the other params
         // since no swap on 0x will be done
         quote = _getBuyUnderlyingQuote(adapter, address(token));
-        _addLiquidityFromToken(adapter, maturity, quote, amt);
+        _addLiquidityFromToken(adapter, maturity, quote, amt, false);
         deal(AddressBook.WSTETH, address(periphery), 0); // reset Periphery's target balance
 
         // 3.2 Add liquidity from Target
@@ -645,7 +641,7 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         // will be ignored in this case. When adding liquidity, buyToken would always be the LP token
         quote = _getBuyUnderlyingQuote(adapter, address(token));
         quote.buyToken = ERC20(AddressBook.DAI);
-        _addLiquidityFromToken(adapter, maturity, quote, amt);
+        _addLiquidityFromToken(adapter, maturity, quote, amt, false);
         deal(AddressBook.WSTETH, address(periphery), 0); // reset Periphery's target balance
 
         // 4. Add liquidity from Underlying
@@ -654,7 +650,7 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         // Create quote only with sellToken as target. We don't care about the other params
         // since no swap on 0x will be done
         quote = _getBuyUnderlyingQuote(adapter, address(token));
-        _addLiquidityFromToken(adapter, maturity, quote, amt);
+        _addLiquidityFromToken(adapter, maturity, quote, amt, false);
         deal(AddressBook.WSTETH, address(periphery), 0); // reset Periphery's target balance
 
         // 5. Add liquidity with malformed quote: buyToken is not the underlying
@@ -670,7 +666,7 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         // 3. We wrap DAI for target
         // 5. Since buyToken is now USDC (instead of stETH) and we have received 0 USDC, it will revert
         vm.expectRevert(abi.encodeWithSelector(Errors.ZeroSwapAmt.selector));
-        this._addLiquidityFromToken(adapter, maturity, quote, amt);
+        this._addLiquidityFromToken(adapter, maturity, quote, amt, false);
         vm.stopPrank();
 
         // 6. Add liquidity with malformed quote:
@@ -686,7 +682,7 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         vm.expectRevert();
         // TODO: fix expectRevert
         // vm.expectRevert(abi.encodeWithSelector(Errors.ZeroExSwapFailed.selector, "Dai/insufficient-balance"));
-        this._addLiquidityFromToken(adapter, maturity, quote, amt);
+        this._addLiquidityFromToken(adapter, maturity, quote, amt, false);
     }
 
     function testMainnetRemoveLiquidity() public {
@@ -706,22 +702,22 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         // 1. Remove liquidity to DAI
         // Create quote from 0x API to do an underlying (stETH) to DAI swap
         Periphery.SwapQuote memory quote = _getSellUnderlyingQuote(adapter, AddressBook.DAI);
-        vm.expectEmit(true, true, false, false);
-        emit BoughtTokens(address(quote.sellToken), AddressBook.DAI, 0, 0);
-        _removeLiquidityToToken(adapter, maturity, quote, amt);
+        // vm.expectEmit(true, true, false, false);
+        // emit BoughtTokens(address(quote.sellToken), AddressBook.DAI, 0, 0);
+        _removeLiquidityToToken(adapter, maturity, quote, amt, true);
 
         // 2. Remove liquidity to ETH
         // Create quote from 0x API to do an underlying (stETH) to ETH swap
         quote = _getSellUnderlyingQuote(adapter, periphery.ETH());
-        vm.expectEmit(true, true, false, false);
-        emit BoughtTokens(address(quote.sellToken), periphery.ETH(), 0, 0);
-        _removeLiquidityToToken(adapter, maturity, quote, amt);
+        // vm.expectEmit(true, true, false, false);
+        // emit BoughtTokens(address(quote.sellToken), periphery.ETH(), 0, 0);
+        _removeLiquidityToToken(adapter, maturity, quote, amt, true);
 
         // 3.1 Remove liquidity to Target
         // Create quote only with buyToken as target. We don't care about the other params
         // since no swap on 0x will be done
         quote = _getSellUnderlyingQuote(adapter, MockAdapter(adapter).target());
-        _removeLiquidityToToken(adapter, maturity, quote, amt);
+        _removeLiquidityToToken(adapter, maturity, quote, amt, true);
 
         // 3.2 Remove liquidity to Target
         // Create quote only with buyToken as target. We don't care about the other params
@@ -729,13 +725,13 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         // will be ignored in this case. When removing liquidity, sellToken would always be the LP token
         quote = _getSellUnderlyingQuote(adapter, MockAdapter(adapter).target());
         quote.sellToken = ERC20(AddressBook.DAI);
-        _removeLiquidityToToken(adapter, maturity, quote, amt);
+        _removeLiquidityToToken(adapter, maturity, quote, amt, true);
 
         // 4. Remove liquidity to Underlying
         // Create quote only with sellToken as target. We don't care about the other params
         // since no swap on 0x will be done
         quote = _getSellUnderlyingQuote(adapter, MockAdapter(adapter).underlying());
-        _removeLiquidityToToken(adapter, maturity, quote, amt);
+        _removeLiquidityToToken(adapter, maturity, quote, amt, true);
 
         // 5. Remove liquidity with malformed quote: buyToken is USDC but not DAI
         // Create quote from 0x API to do an underlying (stETH) to DAI swap
@@ -749,7 +745,7 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         // 4. We succefully execute a 0x swap from stETH to DAI (because that's what's in swapCallData)
         // 5. Since buyToken is now USDC and we have received 0 USDC, it will revert
         vm.expectRevert(abi.encodeWithSelector(Errors.ZeroSwapAmt.selector));
-        this._removeLiquidityToToken(adapter, maturity, quote, amt);
+        this._removeLiquidityToToken(adapter, maturity, quote, amt, false);
 
         // 6. Remove liquidity with malformed quote: sellToken is USDC but not stETH
         // Create quote from 0x API to do an underlying (stETH) to DAI swap
@@ -765,7 +761,7 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         vm.expectRevert();
         // vm.expectRevert(abi.encodeWithSelector(Errors.ZeroExSwapFailed.selector, "TRANSFER_AMOUNT_EXCEEDS_ALLOWANCE"));
         // TODO: fix expectRevert
-        this._removeLiquidityToToken(adapter, maturity, quote, amt);
+        this._removeLiquidityToToken(adapter, maturity, quote, amt, false);
     }
 
     /* ========== PT SWAPS ========== */
@@ -787,21 +783,19 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         uint256 amt = 10**token.decimals(); // 1 DAI
         // Create quote from 0x API to do a 1 DAI to underlying swap
         Periphery.SwapQuote memory quote = _getBuyUnderlyingQuote(adapter, address(token));
-        vm.expectEmit(true, true, false, false);
-        emit BoughtTokens(address(token), address(quote.buyToken), 0, 0);
-        _swapTokenForPTs(adapter, maturity, quote, amt);
+        _swapTokenForPTs(adapter, maturity, quote, amt, true);
 
         // 2. Swap target for PTs
         ERC20 target = ERC20(MockAdapter(adapter).target());
         amt = 10**(target.decimals() - 1); // 0.1 target
         quote = _getBuyUnderlyingQuote(adapter, address(target));
-        _swapTokenForPTs(adapter, maturity, quote, amt);
+        _swapTokenForPTs(adapter, maturity, quote, amt, true);
 
         // 3. Swap underlying for PTs
         ERC20 underlying = ERC20(MockAdapter(adapter).underlying());
         amt = 10**(underlying.decimals() - 1); // 0.1 underlying
         quote = _getBuyUnderlyingQuote(adapter, address(underlying));
-        _swapTokenForPTs(adapter, maturity, quote, amt);
+        _swapTokenForPTs(adapter, maturity, quote, amt, true);
 
         // 4. Swap DAI for PTs with malformed quote: buyToken is not underlying but USDC
         token = ERC20(AddressBook.DAI);
@@ -815,7 +809,7 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         // 2. We succefully execute a 0x swap from DAI to stETH
         // Since buyToken is now USDC and we have received 0 USDC, it will revert
         vm.expectRevert(abi.encodeWithSelector(Errors.ZeroSwapAmt.selector));
-        this._swapTokenForPTs(adapter, maturity, quote, amt);
+        this._swapTokenForPTs(adapter, maturity, quote, amt, false);
 
         // 5. Swap DAI for PTs with malformed quote: sellToken is not DAI but USDC and has USDC permit2 approvals and balances
         token = ERC20(AddressBook.DAI);
@@ -830,7 +824,7 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         // TODO: fix expectRevert
         // vm.expectRevert(abi.encodeWithSelector(Errors.ZeroExSwapFailed.selector, "Dai/insufficient-balance"));
         vm.expectRevert();
-        this._swapTokenForPTs(adapter, maturity, quote, amt);
+        this._swapTokenForPTs(adapter, maturity, quote, amt, false);
 
         // 6. Can't swap if deadline expires
         vm.warp(DEADLINE + 1);
@@ -839,7 +833,7 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         // Create quote from 0x API to do a 1 DAI to underlying swap
         quote = _getBuyUnderlyingQuote(adapter, address(token));
         vm.expectRevert("BAL#508"); // #508 = SWAP_DEADLINE
-        this._swapTokenForPTs(adapter, maturity, quote, amt);
+        this._swapTokenForPTs(adapter, maturity, quote, amt, false);
     }
 
     function testMainnetSwapPTsForAll() public {
@@ -856,11 +850,11 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
 
         // 1. Swap PTs for target
         Periphery.SwapQuote memory quote = _getSellUnderlyingQuote(adapter, MockAdapter(adapter).target());
-        _swapPTs(adapter, maturity, 0, quote);
+        _swapPTs(adapter, maturity, 0, quote, true);
 
         // 2. Swap PTs for underlying
         quote = _getSellUnderlyingQuote(adapter, MockAdapter(adapter).underlying());
-        _swapPTs(adapter, maturity, 0, quote);
+        _swapPTs(adapter, maturity, 0, quote, true);
 
         // 3. Swap PTs for DAI
         // Create 0x API quote to do a X underlying to token swap
@@ -869,11 +863,9 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         uint256 daiOut = _callStaticSwapPTs(adapter, maturity, quote);
 
         vm.expectRevert(abi.encodeWithSelector(Errors.UnexpectedSwapAmount.selector));
-        this._swapPTs(adapter, maturity, daiOut + 1, quote);
+        this._swapPTs(adapter, maturity, daiOut + 1, quote, false);
 
-        vm.expectEmit(true, true, false, false);
-        emit BoughtTokens(MockAdapter(adapter).underlying(), AddressBook.DAI, 0, 0);
-        _swapPTs(adapter, maturity, daiOut, quote);
+        _swapPTs(adapter, maturity, daiOut, quote, true);
 
         // 4. Swap PTs with malformed quote: sellToken is not underlying but USDC
         // Create 0x API quote to do a X underlying to token swap
@@ -887,7 +879,7 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         // TODO: fix expectRevert
         // vm.expectRevert(abi.encodeWithSelector(Errors.ZeroExSwapFailed.selector, "Dai/insufficient-balance"));
         vm.expectRevert();
-        this._swapPTs(adapter, maturity, 0, quote);
+        this._swapPTs(adapter, maturity, 0, quote, false);
     }
 
     /* ========== YT SWAPS ========== */
@@ -1612,7 +1604,7 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         Periphery.SwapQuote memory quote
     ) public {
         vm.prank(bob);
-        uint256 tokenReturned = _swapPTs(adapter, maturity, 0, quote);
+        uint256 tokenReturned = _swapPTs(adapter, maturity, 0, quote, true);
         revert(string(abi.encode(tokenReturned)));
     }
 
@@ -1811,35 +1803,41 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         address adapter,
         uint256 maturity,
         Periphery.SwapQuote memory quote,
-        uint256 amt
+        uint256 amt,
+        bool emitEvent
     ) public {
-        ERC20 token = ERC20(address(quote.sellToken));
-
         // 1. Load token into Bob's address
-        if (address(token) == AddressBook.STETH) {
+        if (address(quote.sellToken) == AddressBook.STETH) {
             // get steth by unwrapping wsteth because `deal()` won't work
             deal(AddressBook.WSTETH, bob, amt);
             vm.prank(bob);
             WstETHLike(AddressBook.WSTETH).unwrap(amt);
         } else {
-            deal(address(token), bob, amt);
+            deal(address(quote.sellToken), bob, amt);
         }
 
         // 2. Approve PERMIT2 to spend token
         vm.prank(bob);
-        token.approve(AddressBook.PERMIT2, type(uint256).max);
+        quote.sellToken.approve(AddressBook.PERMIT2, type(uint256).max);
 
         // 3. Generate permit message and signature
-        Periphery.PermitData memory data = generatePermit(bobPrivKey, address(periphery), address(token));
+        Periphery.PermitData memory data = generatePermit(bobPrivKey, address(periphery), address(quote.sellToken));
 
         // 4. Swap Token for PTs
         uint256 ptBalPre = ERC20(Divider(divider).pt(adapter, maturity)).balanceOf(bob);
-        uint256 tokenBalPre = token.balanceOf(bob);
+        uint256 tokenBalPre = quote.sellToken.balanceOf(bob);
+
+        if (emitEvent) {
+            if (address(quote.buyToken) != address(0)) {
+                vm.expectEmit(true, true, false, false);
+                emit BoughtTokens(address(quote.sellToken), address(quote.buyToken), 0, 0);
+            }
+        }
 
         vm.prank(bob);
         uint256 ptBal = periphery.swapForPTs(adapter, maturity, amt, DEADLINE, 0, bob, data, quote);
 
-        uint256 tokenBalPost = token.balanceOf(bob);
+        uint256 tokenBalPost = quote.sellToken.balanceOf(bob);
         uint256 ptBalPost = ERC20(Divider(divider).pt(adapter, maturity)).balanceOf(bob);
 
         // Check that the return values reflect the token balance changes
@@ -1851,9 +1849,9 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         address adapter,
         uint256 maturity,
         uint256 minAccepted,
-        Periphery.SwapQuote memory quote
+        Periphery.SwapQuote memory quote,
+        bool emitEvent
     ) public returns (uint256 tokenOut) {
-        ERC20 token = ERC20(address(quote.buyToken));
         // 0. Get PT address
         address pt = Divider(divider).pt(adapter, maturity);
 
@@ -1878,11 +1876,18 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         {
             // 4. Swap PTs for Token
             uint256 ptBalPre = ERC20(pt).balanceOf(bob);
-            uint256 tokenBalPre = token.balanceOf(bob);
+            uint256 tokenBalPre = quote.buyToken.balanceOf(bob);
+
+            if (emitEvent) {
+                if (address(quote.sellToken) != address(0)) {
+                    vm.expectEmit(true, true, false, false);
+                    emit BoughtTokens(MockAdapter(adapter).underlying(), address(quote.buyToken), 0, 0);
+                }
+            }
 
             vm.prank(bob);
             tokenOut = periphery.swapPTs(adapter, maturity, ptBalPre, DEADLINE, minAccepted, bob, data, quote);
-            uint256 tokenBalPost = token.balanceOf(bob);
+            uint256 tokenBalPost = quote.buyToken.balanceOf(bob);
             uint256 ptBalPost = ERC20(pt).balanceOf(bob);
 
             // Check that the return values reflect the token balance changes
@@ -1895,7 +1900,8 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         address adapter,
         uint256 maturity,
         Periphery.SwapQuote memory quote,
-        uint256 amt
+        uint256 amt,
+        bool emitEvent
     ) public {
         ERC20 token = ERC20(address(quote.sellToken));
 
@@ -1919,7 +1925,7 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         uint256 lpBalPre = ERC20(SpaceFactoryLike(spaceFactory).pools(address(adapter), maturity)).balanceOf(bob);
 
         {
-            uint256 lpShares = _addLiquidity(adapter, maturity, quote, amt);
+            uint256 lpShares = _addLiquidity(adapter, maturity, quote, amt, emitEvent);
             // Check that the return values reflect the token balance changes
             assertApproxEqAbs(tokenBalPre, token.balanceOf(bob) + amt, 4);
             assertEq(
@@ -1936,7 +1942,8 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         address adapter,
         uint256 maturity,
         Periphery.SwapQuote memory quote,
-        uint256 amt
+        uint256 amt,
+        bool emitEvent
     ) public {
         address sellToken = address(quote.sellToken);
 
@@ -1948,7 +1955,7 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         uint256 lpBalPre = ERC20(SpaceFactoryLike(spaceFactory).pools(address(adapter), maturity)).balanceOf(bob);
 
         {
-            uint256 lpShares = _addLiquidity(adapter, maturity, quote, amt);
+            uint256 lpShares = _addLiquidity(adapter, maturity, quote, amt, emitEvent);
             // Check that the return values reflect the token balance changes
             assertEq(ethBalPre, address(bob).balance + amt);
             assertEq(
@@ -1965,8 +1972,16 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         address adapter,
         uint256 maturity,
         Periphery.SwapQuote memory quote,
-        uint256 amt
+        uint256 amt,
+        bool emitEvent
     ) internal returns (uint256 lpShares) {
+        if (emitEvent) {
+            if (address(quote.sellToken) != address(0)) {
+                vm.expectEmit(true, true, false, false);
+                emit BoughtTokens(address(quote.sellToken), MockAdapter(adapter).underlying(), 0, 0);
+            }
+        }
+
         vm.startPrank(bob);
         (, , lpShares) = periphery.addLiquidity{ value: address(quote.sellToken) == periphery.ETH() ? amt : 0 }(
             adapter,
@@ -1985,7 +2000,8 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         address adapter,
         uint256 maturity,
         Periphery.SwapQuote memory quote,
-        uint256 amt
+        uint256 amt,
+        bool emitEvent
     ) public {
         bool isETH = address(quote.buyToken) == periphery.ETH();
         ERC20 token = quote.buyToken;
@@ -2005,7 +2021,7 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         uint256 ptBalPre = pt.balanceOf(bob);
 
         {
-            (uint256 tBal, uint256 ptBal) = _removeLiquidity(adapter, maturity, quote, amt);
+            (uint256 tBal, uint256 ptBal) = _removeLiquidity(adapter, maturity, quote, amt, emitEvent);
             // Check that the return values reflect the token balance changes
             assertEq(lp.balanceOf(bob), lpBalPre - amt);
             assertEq(pt.balanceOf(bob), ptBalPre + ptBal);
@@ -2022,9 +2038,24 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         address adapter,
         uint256 maturity,
         Periphery.SwapQuote memory quote,
-        uint256 amt
+        uint256 amt,
+        bool emitEvent
     ) internal returns (uint256 tBal, uint256 ptBal) {
         address lp = SpaceFactoryLike(spaceFactory).pools(address(adapter), maturity);
+
+        Periphery.PermitData memory data = generatePermit(bobPrivKey, address(periphery), lp);
+
+        if (emitEvent) {
+            if (
+                address(quote.buyToken) != address(0) &&
+                address(quote.buyToken) != MockAdapter(adapter).underlying() &&
+                address(quote.buyToken) != MockAdapter(adapter).target()
+            ) {
+                vm.expectEmit(true, true, false, false);
+                emit BoughtTokens(MockAdapter(adapter).underlying(), address(quote.buyToken), 0, 0);
+            }
+        }
+
         vm.startPrank(bob);
         (tBal, ptBal) = periphery.removeLiquidity(
             adapter,
@@ -2033,7 +2064,7 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
             Periphery.RemoveLiquidityParams(0, new uint256[](2), DEADLINE),
             true, // swap PTs for tokens
             bob,
-            generatePermit(bobPrivKey, address(periphery), lp),
+            data,
             quote
         );
         vm.stopPrank();

--- a/pkg/core/src/tests/Periphery.tm.sol
+++ b/pkg/core/src/tests/Periphery.tm.sol
@@ -944,6 +944,25 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         assertGt(targetBalPost, targetBalPre);
     }
 
+
+    function testMainnetCannotCallSwapYTsForTargetHelper() public {
+        // 1. Sponsor a Series
+        (uint256 maturity, address pt, address yt) = _sponsorSeries();
+
+        // 2. Initialize the pool by joining 0.5 Target in, then swapping 0.5 PTs in for Target
+        _initializePool(maturity, ERC20(pt), 1e18, 0.5e18);
+
+        // 3. Swap 10% of bob's YTs for Target
+        vm.startPrank(bob);
+        uint256 ytBalPre = ERC20(yt).balanceOf(bob);
+        uint256 targetBalPre = mockTarget.balanceOf(bob);
+
+        Periphery.PermitData memory data = generatePermit(bobPrivKey, address(periphery), address(yt));
+
+        vm.expectRevert(Errors.OnlyPeriphery.selector);
+        periphery.swapYTsForTargetHelper(bob, address(mockAdapter), maturity, ytBalPre / 10, data);
+    }
+
     function testMainnetSwapTargetForYTsReturnValues() public {
         // 1. Sponsor a Series
         (uint256 maturity, address pt, address yt) = _sponsorSeries();

--- a/pkg/core/src/tests/Periphery.tm.sol
+++ b/pkg/core/src/tests/Periphery.tm.sol
@@ -944,6 +944,24 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
         assertGt(targetBalPost, targetBalPre);
     }
 
+    function testMainnetFuzzCannotCallSwapYTsForTargetHelper(address from) public {
+        // 1. Sponsor a Series
+        (uint256 maturity, address pt, address yt) = _sponsorSeries();
+
+        // 2. Initialize the pool by joining 0.5 Target in, then swapping 0.5 PTs in for Target
+        _initializePool(maturity, ERC20(pt), 1e18, 0.5e18);
+
+        // 3. Swap 10% of bob's YTs for Target
+        vm.startPrank(from);
+        uint256 ytBalPre = ERC20(yt).balanceOf(bob);
+        uint256 targetBalPre = mockTarget.balanceOf(bob);
+
+        Periphery.PermitData memory data = generatePermit(bobPrivKey, address(periphery), address(yt));
+
+        vm.expectRevert(Errors.OnlyPeriphery.selector);
+        periphery.swapYTsForTargetHelper(bob, address(mockAdapter), maturity, ytBalPre / 10, data);
+    }
+
     function testMainnetSwapTargetForYTsReturnValues() public {
         // 1. Sponsor a Series
         (uint256 maturity, address pt, address yt) = _sponsorSeries();

--- a/pkg/core/src/tests/Periphery.tm.sol
+++ b/pkg/core/src/tests/Periphery.tm.sol
@@ -892,7 +892,7 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
 
     /* ========== YT SWAPS ========== */
 
-    function testMainnetSwapYTsForTarget() public {
+    function testMainnetSwapYTs() public {
         // 1. Sponsor a Series
         (uint256 maturity, address pt, address yt) = _sponsorSeries();
 
@@ -915,6 +915,27 @@ contract PeripheryMainnetTests is PeripheryTestHelper {
             data,
             _getSellUnderlyingQuote(address(mockAdapter), address(mockTarget))
         );
+        uint256 ytBalPost = ERC20(yt).balanceOf(bob);
+        uint256 targetBalPost = mockTarget.balanceOf(bob);
+
+        // Check that this address has fewer YTs and more Target
+        assertLt(ytBalPost, ytBalPre);
+        assertGt(targetBalPost, targetBalPre);
+    }
+
+    function testMainnetSwapYTsForTarget() public {
+        // 1. Sponsor a Series
+        (uint256 maturity, address pt, address yt) = _sponsorSeries();
+
+        // 2. Initialize the pool by joining 0.5 Target in, then swapping 0.5 PTs in for Target
+        _initializePool(maturity, ERC20(pt), 1e18, 0.5e18);
+
+        // 3. Swap 10% of bob's YTs for Target
+        vm.startPrank(bob);
+        uint256 ytBalPre = ERC20(yt).balanceOf(bob);
+        uint256 targetBalPre = mockTarget.balanceOf(bob);
+        ERC20(yt).approve(address(periphery), ytBalPre / 10);
+        periphery.swapYTsForTarget(address(mockAdapter), maturity, ytBalPre / 10);
         uint256 ytBalPost = ERC20(yt).balanceOf(bob);
         uint256 targetBalPost = mockTarget.balanceOf(bob);
 

--- a/pkg/deployments/deploy/prod/06-series.js
+++ b/pkg/deployments/deploy/prod/06-series.js
@@ -71,26 +71,9 @@ module.exports = async function () {
       chainId,
       signer,
     );
-    console.log("signature", signature);
-    console.log("message", message);
-    console.log("chainId", chainId);
 
     console.info(` - Swap ${isETH ? "ETH" : await sellToken.symbol()} for PTs...`);
     const { sellTokenAddress, buyTokenAddress, allowanceTarget, to, data } = quote;
-
-    console.log(
-      "message",
-      adapter.address,
-      maturity,
-      one(decimals),
-      0, // min amount out
-      deployer,
-      { msg: message, sig: signature },
-      [sellTokenAddress, buyTokenAddress, allowanceTarget, to, data],
-      {
-        value: isETH ? one(decimals) : 0,
-      },
-    );
 
     let receipt = await (
       await periphery.swapForPTs(
@@ -563,18 +546,16 @@ module.exports = async function () {
           signer,
         );
         const quote = [stake.address, stake.address, stakeSize, zeroAddress(), zeroAddress(), "0x"];
-        const { pt: _ptAddress, yt: _ytAddress } = await periphery.callStatic.sponsorSeries(
-          adapter.address,
-          seriesMaturity,
-          true,
-          { msg: message, sig: signature },
-          quote,
-        );
+        const { pt: _ptAddress, yt: _ytAddress } = await periphery.callStatic[
+          "sponsorSeries(address,uint256,bool,(((address,uint256),uint256,uint256),bytes),(address,address,uint256,address,address,bytes))"
+        ](adapter.address, seriesMaturity, true, { msg: message, sig: signature }, quote);
         ptAddress = _ptAddress;
         ytAddress = _ytAddress;
-        await periphery
-          .sponsorSeries(adapter.address, seriesMaturity, true, { msg: message, sig: signature }, quote)
-          .then(tx => tx.wait());
+        await periphery[
+          "sponsorSeries(address,uint256,bool,(((address,uint256),uint256,uint256),bytes),(address,address,uint256,address,address,bytes))"
+        ](adapter.address, seriesMaturity, true, { msg: message, sig: signature }, quote).then(tx =>
+          tx.wait(),
+        );
         log(`${"✔"} Series successfully sponsored`);
       }
       log("\n-------------------------------------------------------\n");

--- a/pkg/deployments/deploy/simulated/06-series.js
+++ b/pkg/deployments/deploy/simulated/06-series.js
@@ -88,18 +88,16 @@ module.exports = async function () {
           signer,
         );
         quote = [stake.address, stake.address, stakeSize, zeroAddress(), zeroAddress(), "0x"];
-        const { pt: _ptAddress, yt: _ytAddress } = await periphery.callStatic.sponsorSeries(
-          adapter.address,
-          seriesMaturity,
-          true,
-          { msg: message, sig: signature },
-          quote,
-        );
+        const { pt: _ptAddress, yt: _ytAddress } = await periphery.callStatic[
+          "sponsorSeries(address,uint256,bool,(((address,uint256),uint256,uint256),bytes),(address,address,uint256,address,address,bytes))"
+        ](adapter.address, seriesMaturity, true, { msg: message, sig: signature }, quote);
         ptAddress = _ptAddress;
         ytAddress = _ytAddress;
-        await periphery
-          .sponsorSeries(adapter.address, seriesMaturity, true, { msg: message, sig: signature }, quote)
-          .then(tx => tx.wait());
+        await periphery[
+          "sponsorSeries(address,uint256,bool,(((address,uint256),uint256,uint256),bytes),(address,address,uint256,address,address,bytes))"
+        ](adapter.address, seriesMaturity, true, { msg: message, sig: signature }, quote).then(tx =>
+          tx.wait(),
+        );
       }
 
       const { abi: tokenAbi } = await deployments.getArtifact("Token");

--- a/pkg/deployments/hardhat.utils.js
+++ b/pkg/deployments/hardhat.utils.js
@@ -316,7 +316,11 @@ exports.getQuote = async (sellTokenAddr, buyTokenAddr, sellAmount) => {
   const API_QUOTE_URL = "https://api.0x.org/swap/v1/quote";
   const quoteUrl = `${API_QUOTE_URL}?${qs}`;
   console.info(`  * Fetching quote ${quoteUrl}...`);
-  const response = await fetch(quoteUrl);
+  const response = await fetch(quoteUrl, {
+    headers: {
+      "0x-api-key": process.env.ZEROEX_API_KEY,
+    },
+  });
   const quote = await response.json();
   console.info(`  * Received a quote with price ${quote.price}`);
   return quote;

--- a/pkg/deployments/hardhat.utils.js
+++ b/pkg/deployments/hardhat.utils.js
@@ -155,6 +155,11 @@ async function stopPrank(address) {
 }
 exports.stopPrank = stopPrank;
 
+async function fund(signer, to, value) {
+  await signer.sendTransaction({ to, value }).then(t => t.wait());
+}
+exports.fund = fund;
+
 const delay = n => new Promise(r => setTimeout(r, n * 1000));
 exports.delay = delay;
 
@@ -227,7 +232,7 @@ exports.generateTokens = async (tokenAddress, to, signer, amt) => {
     index.toString(),
     this.toBytes32(amt || ethers.utils.parseEther("10000000")).toString(),
   );
-  if ((await token.balanceOf(to)).eq(0)) {
+  if ((await token.balanceOf(to)).lt(amt)) {
     throw new Error(`\n - Failed to generate ${amt} ${symbol} to deployer: ${to}`);
   }
 };

--- a/pkg/deployments/package.json
+++ b/pkg/deployments/package.json
@@ -24,7 +24,7 @@
     "prepare": "cp -n ../../.env ./.env || true && git submodule update --init --recursive",
     "lint": "eslint .",
     "fix": "prettier . --write && yarn lint --fix",
-    "task": "cp ../../.env ./.env && yarn hardhat"
+    "task": "yarn hardhat compile && cp ../../.env ./.env && yarn hardhat"
   },
   "dependencies": {
     "@balancer-labs/v2-pool-utils": "2.0.1",

--- a/pkg/deployments/tasks/20230301-periphery-v2/index.js
+++ b/pkg/deployments/tasks/20230301-periphery-v2/index.js
@@ -5,7 +5,6 @@ const { SENSE_MULTISIG, CHAINS, VERIFY_CHAINS } = require("../../hardhat.address
 const { verifyOnEtherscan } = require("../../hardhat.utils");
 
 task("20230301-periphery-v2", "Deploys and authenticates Periphery V2").setAction(async (_, { ethers }) => {
-  const { deploy } = deployments;
   const { deployer } = await getNamedAccounts();
   const chainId = await getChainId();
   const deployerSigner = await ethers.getSigner(deployer);
@@ -88,7 +87,7 @@ task("20230301-periphery-v2", "Deploys and authenticates Periphery V2").setActio
     "0x529c90E6d3a1AedaB9B3011196C495439D23b893".toLowerCase(),
     "0x8c5e7301a012DC677DD7DaD97aE44032feBCD0FD".toLowerCase(),
     "0x86c55BFFb64f8fCC8beA33F3176950FDD0fb160D".toLowerCase(),
-  ]
+  ];
 
   let verified = [
     "0x36c744Dd2916E9E04173Bee9d93D554f955a999d".toLowerCase(),
@@ -100,7 +99,7 @@ task("20230301-periphery-v2", "Deploys and authenticates Periphery V2").setActio
     "0x529c90E6d3a1AedaB9B3011196C495439D23b893".toLowerCase(),
     "0x8c5e7301a012DC677DD7DaD97aE44032feBCD0FD".toLowerCase(),
     // "0x86c55BFFb64f8fCC8beA33F3176950FDD0fb160D".toLowerCase(), PENDING
-  ]
+  ];
 
   for (let adapter of adaptersOnboarded) {
     console.log("\nOnboarding adapter", adapter);


### PR DESCRIPTION
## Motivation

~Make sure our Periphery V2 is backwards compatible with the RLVs.~
Improve deployment script for Periphery V2 and add sanity checks

## Solution

~`sponsorSeries` signature was modified to it's not compatible anymore with RLVs. Hence, we need to create yet another `sponsorSeries` that behaves the same as in our previous version of the Periphery. Basically, that conforms the following signature:~

~function sponsorSeries(address adapter, uint256 maturity, bool withPool) external payable returns (address pt, address yt);~

~I tried implementing an **internal** `_sponsorSeries()` which is called by 2 **external** `sponsorSeries()` but turned out that that approach was more gas inefficient than just having 2 external `sponsorSeries()` with a bit of code duplication. Seems like in both approaches contract size is still fine.~

Deployment script has been updated to include some sanity checks (basically, checking that we can `roll()` on the new Periphery).

Friendly reminder on how to run the deployment script in fork mode:
```
cd /sense-v1/pkg/deployments
yarn task 20230301-periphery-v2 --network hardhat
```

UPDATE: 
Seems like we found the PR that was implementing the `sponsorSeries` backwards-compatible function. It was [here](Looks like it links to this one, which does have the sponsorSeries change <a:thinkingspaz:910000833230417942> https://github.com/sense-finance/sense-v1/pull/360). So this PR is just about polishing the deployment script.

## Implementer Checklist

<!--
Fill out the checklist below as applicable to your change. Bug fixes and new features must 
check off all of the required items.
-->

- [ ]  [OPTIONAL] Create a reference implementation (in python or JS)
- [x]  Create a short "Motivation" section for the PR
- [x]  Write a spec for the feature and put it in the PR description – basic function names and expected state transitions is OK
- [ ]  Get the PR reviewed by at least two people

If this is your first time reviewing smart contract changes
- [ ]  Review the [Solcurity](https://github.com/Rari-Capital/solcurity) standard


If smart contract changes were made
- [ ]  Check all of the new revert paths with concrete tests
- [ ]  Check all of the new storage slot writes with concrete tests – do not make the passing test case the trivial case!
- [x]  Go line-by-line through the new code and ensure it has all been covered by concrete tests – since we don’t have a coverage engine for foundry yet, you can imagine how one might check that each different code path is covered
- [x]  Simplify the implementation and spend some time trying to minimize gas costs
- [x]  Write fuzz tests for the feature – try everything to break the implementation (is this function monotonically in/decreasing, should it always be less than something else, etc)
- [ ]  Capture bugs discovered during the above steps in concrete tests (regression tests)
- [x]  Add integration tests – fuzz or concrete tests that test how the new code affects the entire system, either locally or with a mainnet fork
- [ ]  [OPTIONAL] Integrate the feature into the deployment scripts
- [ ]  [OPTIONAL] Add new sanity checks to the deployment scripts

If your PR uses or interacts with prices of any kind
- [ ] Make sure forge is running the test on the latest block
- [ ] Compare the value returned with some other source (like Curve)
- [ ] Check the `updatedAt` (if available) value of the contract and confirm that the price we are sourcing is in fact not older than X
- [ ] Ensure oracle liveness from the oracle maintainer, either through a public status interface or through written confirmation from a developer.